### PR TITLE
Fix C Interface

### DIFF
--- a/include/game_address.h
+++ b/include/game_address.h
@@ -133,40 +133,44 @@ class DLLEXPORT GameAddress {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GameAddress {
-  // sgd2mapi::GameAddress*
-  void* game_address;
-};
+struct SGD2MAPI_GameAddress;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-DLLEXPORT void SGD2MAPI_GameAddress_CreateAsGameAddressFromLibraryPath(
-    struct SGD2MAPI_GameAddress* dest,
+/**
+ * Creates a new GameAddress. The base library is specified using its name.
+ * The game address locators are specified as an array of pointers to
+ * GameAddressLocators.
+ */
+DLLEXPORT struct SGD2MAPI_GameAddress*
+SGD2MAPI_GameAddress_CreateAsGameAddressFromLibraryPath(
     const char* library_path,
-    const struct SGD2MAPI_GameAddressLocatorInterface**
-        game_address_locator_interfaces
-);
-
-DLLEXPORT void SGD2MAPI_GameAddress_CreateAsGameAddressFromLibraryId(
-    struct SGD2MAPI_GameAddress* dest,
-    enum SGD2MAPI_DefaultLibrary library_id,
-    const struct SGD2MAPI_GameAddressLocatorInterface**
-        game_address_locator_interfaces
+    const struct SGD2MAPI_GameAddressLocatorInterface*
+        game_address_locator_interfaces[]
 );
 
 /**
- * Initializes the value of the specified destination with a new GameAddress
- * using the specified parameters. The library can be either a library ID or
- * the null-terminated string name of the library. The game address locator
- * array is a pointer to a one-dimensional array of pointers to
- * GameAddressLocator objects.
+ * Creates a new GameAddress. The base library is specified using its ID.
+ * The game address locators are specified as an array of pointers to
+ * GameAddressLocators.
+ */
+DLLEXPORT struct SGD2MAPI_GameAddress*
+SGD2MAPI_GameAddress_CreateAsGameAddressFromLibraryId(
+    enum SGD2MAPI_DefaultLibrary c_library_id,
+    const struct SGD2MAPI_GameAddressLocatorInterface*
+        c_game_address_locator_interfaces[]
+);
+
+/**
+ * Create a new GameAddress. The base library is specified using its ID or its
+ * name. The game address locators are specified as an array of pointers to
+ * GameAddressLocators.
  */
 #define SGD2MAPI_GameAddress_Create( \
-    dest, \
     library, \
-    game_address_locator_interfaces \
+    c_game_address_locator_interfaces \
 ) _Generic( \
     (library), \
     char*: \
@@ -178,15 +182,17 @@ DLLEXPORT void SGD2MAPI_GameAddress_CreateAsGameAddressFromLibraryId(
 /**
  * Frees the memory used by the specified game address.
  */
-DLLEXPORT void SGD2MAPI_GameAddress_Destroy(
-    struct SGD2MAPI_GameAddress* game_address
+DLLEXPORT void
+SGD2MAPI_GameAddress_Destroy(
+    struct SGD2MAPI_GameAddress* c_game_address
 );
 
 /**
  * Returns the address value of the game address.
  */
-DLLEXPORT intptr_t SGD2MAPI_GameAddress_GetAddress(
-    const struct SGD2MAPI_GameAddress* game_address
+DLLEXPORT intptr_t
+SGD2MAPI_GameAddress_GetAddress(
+    const struct SGD2MAPI_GameAddress* c_game_address
 );
 
 #ifdef __cplusplus

--- a/include/game_address_locator/game_address_locator_interface.h
+++ b/include/game_address_locator/game_address_locator_interface.h
@@ -78,10 +78,7 @@ class DLLEXPORT GameAddressLocatorInterface {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GameAddressLocatorInterface {
-  // sgd2mapi::GameAddressLocatorInterface*
-  void* game_address_locator_interface;
-};
+struct SGD2MAPI_GameAddressLocatorInterface;
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,8 +87,10 @@ extern "C" {
 /**
  * Frees the memory used by the specified game address locator.
  */
-DLLEXPORT void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-  struct SGD2MAPI_GameAddressLocatorInterface* game_address_locator_interface
+DLLEXPORT void
+SGD2MAPI_GameAddressLocatorInterface_Destroy(
+  struct SGD2MAPI_GameAddressLocatorInterface*
+      c_game_address_locator_interface
 );
 
 #ifdef __cplusplus

--- a/include/game_address_locator/game_offset.h
+++ b/include/game_address_locator/game_offset.h
@@ -97,62 +97,60 @@ class DLLEXPORT GameOffset : public GameAddressLocatorInterface {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GameOffset {
-  // sgd2mapi::GameOffset*
-  void* game_offset;
-};
+struct SGD2MAPI_GameOffset;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-DLLEXPORT void SGD2MAPI_GameOffset_CreateAsGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface* dest,
-    intptr_t offset
-);
-
-DLLEXPORT void SGD2MAPI_GameOffset_CreateAsGameOffset(
-    struct SGD2MAPI_GameOffset* dest,
+/**
+ * Creates a new GameOffset, upcasted to a GameAddressLocatorInterface.
+ */
+DLLEXPORT struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOffset_CreateAsGameAddressLocatorInterface(
     intptr_t offset
 );
 
 /**
- * Initializes the specified destination with a new GameOffset.
+ * Creates a new GameOffset.
  */
-#define SGD2MAPI_GameOffset_Create(dest, offset) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GameAddressLocatorInterface*: \
-        SGD2MAPI_GameOffset_CreateAsGameAddressLocatorInterface, \
-    struct SGD2MAPI_GameOffset*: \
-        SGD2MAPI_GameOffset_CreateAsGameOffset \
-)(dest, offset)
+DLLEXPORT struct SGD2MAPI_GameOffset*
+SGD2MAPI_GameOffset_Create(
+    intptr_t offset
+);
 
 /**
  * Frees the memory used by the specified game locator.
  */
-DLLEXPORT void SGD2MAPI_GameOffset_Destroy(
-    struct SGD2MAPI_GameOffset* game_offset
-);
-
-DLLEXPORT void SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface* dest,
-    const struct SGD2MAPI_GameOffset* game_offset
+DLLEXPORT void
+SGD2MAPI_GameOffset_Destroy(
+    struct SGD2MAPI_GameOffset* c_game_offset
 );
 
 /**
- * Upcasts the game locator to a parent type, into the destination.
+ * Creates an upcast of the specified game locator to a
+ * GameAddressLocatorInterface.
  */
-#define SGD2MAPI_GameOffset_Upcast(dest, game_offset) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GameAddressLocatorInterface*: \
-        SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterface \
-)(dest, game_offset)
+DLLEXPORT struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterface(
+    const struct SGD2MAPI_GameOffset* c_game_offset
+);
+
+/**
+ * Creates an upcast of the specified game locator to a
+ * GameAddressLocatorInterface and destroys the specified game locator.
+ */
+DLLEXPORT struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterfaceThenDestroy(
+    struct SGD2MAPI_GameOffset* c_game_offset
+);
 
 /**
  * Returns the offset value of the game locator.
  */
-DLLEXPORT intptr_t SGD2MAPI_GameOffset_GetOffset(
-    const struct SGD2MAPI_GameOffset* game_offset
+DLLEXPORT intptr_t
+SGD2MAPI_GameOffset_GetOffset(
+    const struct SGD2MAPI_GameOffset* c_game_offset
 );
 
 #ifdef __cplusplus

--- a/include/game_address_locator/game_ordinal.h
+++ b/include/game_address_locator/game_ordinal.h
@@ -95,63 +95,60 @@ class DLLEXPORT GameOrdinal : public GameAddressLocatorInterface {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GameOrdinal {
-  // sgd2mapi::GameOrdinal*
-  void* game_ordinal;
-};
+struct SGD2MAPI_GameOrdinal;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-DLLEXPORT void SGD2MAPI_GameOrdinal_CreateAsGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface* dest,
-    int ordinal
-);
-
-DLLEXPORT void SGD2MAPI_GameOrdinal_CreateAsGameOrdinal(
-    struct SGD2MAPI_GameOrdinal* dest,
+/**
+ * Creates a new GameOrdinal.
+ */
+DLLEXPORT struct SGD2MAPI_GameOrdinal*
+SGD2MAPI_GameOrdinal_Create(
     int ordinal
 );
 
 /**
- * Initializes the specified destination with a new GameOrdinal.
+ * Creates a new GameOrdinal, upcasted to a GameAddressLocatorInterface.
  */
-#define SGD2MAPI_GameOrdinal_Create(dest, ordinal) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GameAddressLocatorInterface*: \
-        SGD2MAPI_GameOrdinal_CreateAsGameAddressLocatorInterface, \
-    struct SGD2MAPI_GameOrdinal*: \
-        SGD2MAPI_GameOrdinal_CreateAsGameOrdinal \
-)(dest, ordinal)
+DLLEXPORT struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOrdinal_CreateAsGameAddressLocatorInterface(
+    int ordinal
+);
 
 /**
  * Frees the memory used by the specified game locator.
  */
-DLLEXPORT void SGD2MAPI_GameOrdinal_Destroy(
-    struct SGD2MAPI_GameOrdinal* game_ordinal
-);
-
-DLLEXPORT void SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        game_address_locator_interface,
-    const struct SGD2MAPI_GameOrdinal* game_ordinal
+DLLEXPORT void
+SGD2MAPI_GameOrdinal_Destroy(
+    struct SGD2MAPI_GameOrdinal* c_game_ordinal
 );
 
 /**
- * Upcasts the game locator to a parent type, into the destination.
+ * Creates an upcast of the specified game locator to a
+ * GameAddressLocatorInterface.
  */
-#define SGD2MAPI_GameOrdinal_Upcast(dest, game_ordinal) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GameAddressLocatorInterface*: \
-        SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterface \
-)(dest, game_ordinal)
+DLLEXPORT struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterface(
+    const struct SGD2MAPI_GameOrdinal* c_game_ordinal
+);
 
 /**
- * Returns the ordinal value of the game ordinal.
+ * Creates an upcast of the specified game locator to a
+ * GameAddressLocatorInterface and destroys the specified game locator.
  */
-DLLEXPORT int SGD2MAPI_GameOrdinal_GetOrdinal(
-    const struct SGD2MAPI_GameOrdinal* game_ordinal
+DLLEXPORT struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterfaceThenDestroy(
+    struct SGD2MAPI_GameOrdinal* c_game_ordinal
+);
+
+/**
+ * Returns the ordinal value of the game locator.
+ */
+DLLEXPORT int
+SGD2MAPI_GameOrdinal_GetOrdinal(
+    const struct SGD2MAPI_GameOrdinal* c_game_ordinal
 );
 
 #ifdef __cplusplus

--- a/include/game_patch/game_branch_patch.h
+++ b/include/game_patch/game_branch_patch.h
@@ -157,10 +157,7 @@ class DLLEXPORT GameBranchPatch : public GamePatchBase {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GameBranchPatch {
-  // sgd2mapi::GameBranchPatch*
-  void* game_branch_patch;
-};
+struct SGD2MAPI_GameBranchPatch;
 
 /**
  * The branch types that are used to call an inserted function. A call saves
@@ -184,78 +181,72 @@ enum class sgd2mapi::BranchType
 extern "C" {
 #endif // __cplusplus
 
-DLLEXPORT void SGD2MAPI_GameBranchPatch_CreateAsGameBranchPatch(
-    struct SGD2MAPI_GameBranchPatch* dest,
-    const struct SGD2MAPI_GameAddress* game_address,
-    enum SGD2MAPI_BranchType branch_type,
-    void* func(),
-    size_t patch_size
-);
-
-DLLEXPORT void SGD2MAPI_GameBranchPatch_CreateAsGamePatchBase(
-    struct SGD2MAPI_GamePatchBase* dest,
-    const struct SGD2MAPI_GameAddress* game_address,
-    enum SGD2MAPI_BranchType branch_type,
+/**
+ * Creates a new GameBranchPatch. The patch buffer is configured by the
+ * specified branch type, the function to branch to, and the patch size.
+ */
+DLLEXPORT struct SGD2MAPI_GameBranchPatch*
+SGD2MAPI_GameBranchPatch_Create(
+    const struct SGD2MAPI_GameAddress* c_game_address,
+    enum SGD2MAPI_BranchType c_branch_type,
     void* func(),
     size_t patch_size
 );
 
 /**
- * Initializes the specified destination with a new GameBranchPatch,
- * specifying the branch type, the function to branch to, and the patch size.
+ * Creates a new GameBranchPatch. The patch buffer is configured by the
+ * specified branch type, the function to branch to, and the patch size.
  */
-#define SGD2MAPI_GameBranchPatch_Create( \
-    dest, \
-    game_address, \
-    branch_type, \
-    func, \
-    patch_size \
-) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GameBranchPatch*: \
-        SGD2MAPI_GameBranchPatch_CreateAsGameBranchPatch, \
-    struct SGD2MAPI_GamePatchBase*: \
-        SGD2MAPI_GameBranchPatch_CreateAsGamePatchBase \
-)(dest, game_address, branch_type, func, patch_size)
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameBranchPatch_CreateAsGamePatchBase(
+    const struct SGD2MAPI_GameAddress* c_game_address,
+    enum SGD2MAPI_BranchType c_branch_type,
+    void* func(),
+    size_t patch_size
+);
 
 /**
  * Frees the memory used by the specified game patch.
  */
-DLLEXPORT void SGD2MAPI_GameBranchPatch_Destroy(
-    struct SGD2MAPI_GameBranchPatch* game_branch_patch
-);
-
-DLLEXPORT void SGD2MAPI_GameBranchPatch_UpcastToGamePatchBase(
-    struct SGD2MAPI_GamePatchBase* dest,
-    const struct SGD2MAPI_GameBranchPatch* src
+DLLEXPORT void
+SGD2MAPI_GameBranchPatch_Destroy(
+    struct SGD2MAPI_GameBranchPatch* c_game_branch_patch
 );
 
 /**
- * Upcasts the game patch to a parent type, into the destination.
+ * Creates an upcast of the specified game patch to a
+ * GamePatchBase.
  */
-#define SGD2MAPI_GameBranchPatch_Upcast( \
-    dest, \
-    src \
-) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GamePatchBase*: \
-        SGD2MAPI_GameBranchPatch_UpcastToGamePatchBase \
-)(dest, src)
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameBranchPatch_UpcastToGamePatchBase(
+    const struct SGD2MAPI_GameBranchPatch* c_game_branch_patch
+);
+
+/**
+ * Creates an upcast of the specified game patch to a
+ * GamePatchBase and destroys the specified game patch.
+ */
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameBranchPatch_UpcastToGamePatchBaseThenDestroy(
+    struct SGD2MAPI_GameBranchPatch* c_game_branch_patch
+);
 
 /**
  * Applies the game patch by replacing the bytes at its target address with the
  * bytes stored in its buffer.
  */
-DLLEXPORT void SGD2MAPI_GameBranchPatch_Apply(
-    struct SGD2MAPI_GameBranchPatch* game_branch_patch
+DLLEXPORT void
+SGD2MAPI_GameBranchPatch_Apply(
+    struct SGD2MAPI_GameBranchPatch* c_game_branch_patch
 );
 
 /**
  * Removes the effects of the game patch by restoring the original state of the
  * bytes at its target address.
  */
-DLLEXPORT void SGD2MAPI_GameBranchPatch_Remove(
-    struct SGD2MAPI_GameBranchPatch* game_branch_patch
+DLLEXPORT void
+SGD2MAPI_GameBranchPatch_Remove(
+    struct SGD2MAPI_GameBranchPatch* c_game_branch_patch
 );
 
 #ifdef __cplusplus

--- a/include/game_patch/game_buffer_patch.h
+++ b/include/game_patch/game_buffer_patch.h
@@ -133,84 +133,75 @@ class DLLEXPORT GameBufferPatch : public GamePatchBase {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GameBufferPatch {
-  // sgd2mapi::GameBufferPatch*
-  void* game_buffer_patch;
-};
+struct SGD2MAPI_GameBufferPatch;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-DLLEXPORT void SGD2MAPI_GameBufferPatch_CreateAsGameBufferPatch(
-    struct SGD2MAPI_GameBufferPatch* dest,
-    const struct SGD2MAPI_GameAddress* game_address,
-    const uint8_t buffer[],
-    size_t patch_size
-);
-
-DLLEXPORT void SGD2MAPI_GameBufferPatch_CreateAsGamePatchBase(
-    struct SGD2MAPI_GamePatchBase* dest,
-    const struct SGD2MAPI_GameAddress* game_address,
+/**
+ * Creates a new GameNopPatch. The patch buffer is specified as an array
+ * of 8-bit integrals.
+ */
+DLLEXPORT struct SGD2MAPI_GameBufferPatch*
+SGD2MAPI_GameBufferPatch_Create(
+    const struct SGD2MAPI_GameAddress* c_game_address,
     const uint8_t buffer[],
     size_t patch_size
 );
 
 /**
- * Initializes the specified destination with a new GameBufferPatch, specifying
- * the patch buffer with an array of 8-bit bytes.
+ * Creates a new GameNopPatch, upcasted to a GamePatchBase. The patch buffer is
+ * specified as an array of 8-bit integrals.
  */
-#define SGD2MAPI_GameBufferPatch_Create( \
-    dest, \
-    game_address, \
-    buffer, \
-    patch_size \
-) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GameBufferPatch*: \
-        SGD2MAPI_GameBufferPatch_CreateAsGameBufferPatch, \
-    struct SGD2MAPI_GamePatchBase*: \
-        SGD2MAPI_GameBufferPatch_CreateAsGamePatchBase \
-)(dest, game_address, buffer, patch_size)
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameBufferPatch_CreateAsGamePatchBase(
+    const struct SGD2MAPI_GameAddress* c_game_address,
+    const uint8_t buffer[],
+    size_t patch_size
+);
 
 /**
  * Frees the memory used by the specified game patch.
  */
 DLLEXPORT void SGD2MAPI_GameBufferPatch_Destroy(
-    struct SGD2MAPI_GameBufferPatch* game_buffer_patch
-);
-
-DLLEXPORT void SGD2MAPI_GameBufferPatch_UpcastToGamePatchBase(
-    struct SGD2MAPI_GamePatchBase* dest,
-    const struct SGD2MAPI_GameBufferPatch* src
+    struct SGD2MAPI_GameBufferPatch* c_game_buffer_patch
 );
 
 /**
- * Upcasts the game patch to a parent type, into the destination.
+ * Creates an upcast of the specified game patch to a
+ * GamePatchBase.
  */
-#define SGD2MAPI_GameBufferPatch_Upcast( \
-    dest, \
-    src \
-) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GamePatchBase*: \
-        SGD2MAPI_GameBufferPatch_UpcastToGamePatchBase \
-)(dest, src)
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameBufferPatch_UpcastToGamePatchBase(
+    const struct SGD2MAPI_GameBufferPatch* c_game_buffer_patch
+);
+
+/**
+ * Creates an upcast of the specified game patch to a
+ * GamePatchBase and destroys the specified game patch.
+ */
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameBufferPatch_UpcastToGamePatchBaseThenDestroy(
+    struct SGD2MAPI_GameBufferPatch* c_game_buffer_patch
+);
 
 /**
  * Applies the game patch by replacing the bytes at its target address
  * with the bytes stored in its buffer.
  */
-DLLEXPORT void SGD2MAPI_GameBufferPatch_Apply(
-    struct SGD2MAPI_GameBufferPatch* game_buffer_patch
+DLLEXPORT void
+SGD2MAPI_GameBufferPatch_Apply(
+    struct SGD2MAPI_GameBufferPatch* c_game_buffer_patch
 );
 
 /**
  * Removes the effects of the game patch by restoring the original state of the
  * bytes at its target address.
  */
-DLLEXPORT void SGD2MAPI_GameBufferPatch_Remove(
-    struct SGD2MAPI_GameBufferPatch* game_buffer_patch
+DLLEXPORT void
+SGD2MAPI_GameBufferPatch_Remove(
+    struct SGD2MAPI_GameBufferPatch* c_game_buffer_patch
 );
 
 #ifdef __cplusplus

--- a/include/game_patch/game_nop_patch.h
+++ b/include/game_patch/game_nop_patch.h
@@ -100,80 +100,73 @@ class DLLEXPORT GameNopPatch : public GamePatchBase {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GameNopPatch {
-  // sgd2mapi::GameNopPatch*
-  void* game_nop_patch;
-};
+struct SGD2MAPI_GameNopPatch;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-DLLEXPORT void SGD2MAPI_GameNopPatch_CreateAsGameNopPatch(
-    struct SGD2MAPI_GameNopPatch* dest,
-    const struct SGD2MAPI_GameAddress* game_address,
-    size_t patch_size
-);
-
-DLLEXPORT void SGD2MAPI_GameNopPatch_CreateAsGamePatchBase(
-    struct SGD2MAPI_GamePatchBase* dest,
-    const struct SGD2MAPI_GameAddress* game_address,
+/**
+ * Creates a new GameNopPatch. The patch buffer is filled with no-op
+ * instructions to fill at most the specified number of bytes.
+ */
+DLLEXPORT struct SGD2MAPI_GameNopPatch*
+SGD2MAPI_GameNopPatch_Create(
+    const struct SGD2MAPI_GameAddress* c_game_address,
     size_t patch_size
 );
 
 /**
- * Initializes the specified destination with a new GameNopPatch, filling the
- * patch buffer with as many no-op instructions that can fit in a patch buffer
- * of the specified size.
+ * Creates a new GameNopPatch, upcasted to a GamePatchBase. The patch buffer is
+ * filled with no-op instructions to fill at most the specified number of
+ * bytes.
  */
-#define SGD2MAPI_GameNopPatch_Create( \
-    dest \
-) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GameNopPatch*: \
-        SGD2MAPI_GameNopPatch_CreateAsGameNopPatch, \
-    struct SGD2MAPI_GamePatchBase*: \
-        SGD2MAPI_GameNopPatch_CreateAsGamePatchBase \
-)(dest)
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameNopPatch_CreateAsGamePatchBase(
+    const struct SGD2MAPI_GameAddress* c_game_address,
+    size_t patch_size
+);
 
 /**
  * Frees the memory used by the specified game patch.
  */
 DLLEXPORT void SGD2MAPI_GameNopPatch_Destroy(
-    struct SGD2MAPI_GameNopPatch* game_nop_patch
-);
-
-DLLEXPORT void SGD2MAPI_GameNopPatch_UpcastToGamePatchBase(
-    struct SGD2MAPI_GamePatchBase* dest,
-    const struct SGD2MAPI_GameNopPatch* src
+    struct SGD2MAPI_GameNopPatch* c_game_nop_patch
 );
 
 /**
- * Upcasts the game patch to a parent type, into the destination.
+ * Creates an upcast of the specified game patch to a GamePatchBase.
  */
-#define SGD2MAPI_GameNopPatch_Upcast( \
-    dest, \
-    src \
-) _Generic( \
-    (dest), \
-    struct SGD2MAPI_GamePatchBase*: \
-        SGD2MAPI_GameNopPatch_UpcastToGamePatchBase \
-)(dest, src)
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameNopPatch_UpcastToGamePatchBase(
+    const struct SGD2MAPI_GameNopPatch* c_game_nop_patch
+);
+
+/**
+ * Creates an upcast of the specified game patch to a
+ * GamePatchBase and destroys the specified game patch.
+ */
+DLLEXPORT struct SGD2MAPI_GamePatchBase*
+SGD2MAPI_GameNopPatch_UpcastToGamePatchBaseThenDestroy(
+    struct SGD2MAPI_GameNopPatch* c_game_nop_patch
+);
 
 /**
  * Applies the game patch by replacing the bytes at its target address with the
  * bytes stored in its buffer.
  */
-DLLEXPORT void SGD2MAPI_GameNopPatch_Apply(
-    struct SGD2MAPI_GameNopPatch* game_nop_patch
+DLLEXPORT void
+SGD2MAPI_GameNopPatch_Apply(
+    struct SGD2MAPI_GameNopPatch* c_game_nop_patch
 );
 
 /**
  * Removes the effects of the game patch by restoring the original state of the
  * bytes at its target address.
  */
-DLLEXPORT void SGD2MAPI_GameNopPatch_Remove(
-    struct SGD2MAPI_GameNopPatch* game_nop_patch
+DLLEXPORT void
+SGD2MAPI_GameNopPatch_Remove(
+    struct SGD2MAPI_GameNopPatch* c_game_nop_patch
 );
 
 #ifdef __cplusplus

--- a/include/game_patch/game_patch_base.h
+++ b/include/game_patch/game_patch_base.h
@@ -153,10 +153,7 @@ class DLLEXPORT GamePatchBase {
  */
 
 #if !defined(__cplusplus) || defined(SGD2MAPI_DLLEXPORT)
-struct SGD2MAPI_GamePatchBase {
-  // sgd2mapi::GamePatchBase*
-  void* game_patch_base;
-};
+struct SGD2MAPI_GamePatchBase;
 
 #ifdef __cplusplus
 extern "C" {
@@ -165,24 +162,27 @@ extern "C" {
 /**
  * Frees the memory used by the specified game patch.
  */
-DLLEXPORT void SGD2MAPI_GamePatchBase_Destroy(
-    struct SGD2MAPI_GamePatchBase* game_patch_base
+DLLEXPORT void
+SGD2MAPI_GamePatchBase_Destroy(
+    struct SGD2MAPI_GamePatchBase* c_game_patch_base
 );
 
 /**
  * Applies the game patch by replacing the bytes at its target address with the
  * bytes stored in its buffer.
  */
-DLLEXPORT void SGD2MAPI_GamePatchBase_Apply(
-    struct SGD2MAPI_GamePatchBase* game_patch_base
+DLLEXPORT void
+SGD2MAPI_GamePatchBase_Apply(
+    struct SGD2MAPI_GamePatchBase* c_game_patch_base
 );
 
 /**
  * Removes the effects of the game patch by restoring the original state of the
  * bytes at its target address.
  */
-DLLEXPORT void SGD2MAPI_GamePatchBase_Remove(
-    struct SGD2MAPI_GamePatchBase* game_patch_base
+DLLEXPORT void
+SGD2MAPI_GamePatchBase_Remove(
+    struct SGD2MAPI_GamePatchBase* c_game_patch_base
 );
 
 #ifdef __cplusplus

--- a/src/c/game_address.h
+++ b/src/c/game_address.h
@@ -36,23 +36,15 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_C_GAME_ADDRESS_H_
+#define SGD2MAPI_C_GAME_ADDRESS_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../include/game_address.h"
 
-namespace sgd2mapi {
+#include <memory>
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
+struct SGD2MAPI_GameAddress {
+  std::shared_ptr<sgd2mapi::GameAddress> actual_ptr;
+};
 
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_C_GAME_ADDRESS_H_

--- a/src/game_address_locator/c/game_address_locator_interface.h
+++ b/src/game_address_locator/c/game_address_locator_interface.h
@@ -36,23 +36,15 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_ADDRESS_LOCATOR_H_
+#define SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_ADDRESS_LOCATOR_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../../include/game_address_locator/game_address_locator_interface.h"
 
-namespace sgd2mapi {
+#include <memory>
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
+struct SGD2MAPI_GameAddressLocatorInterface {
+  std::shared_ptr<sgd2mapi::GameAddressLocatorInterface> actual_ptr;
+};
 
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_ADDRESS_LOCATOR_H_

--- a/src/game_address_locator/c/game_offset.h
+++ b/src/game_address_locator/c/game_offset.h
@@ -36,23 +36,15 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_OFFSET_H_
+#define SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_OFFSET_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../../include/game_address_locator/game_offset.h"
 
-namespace sgd2mapi {
+#include <memory>
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
+struct SGD2MAPI_GameOffset {
+  std::shared_ptr<sgd2mapi::GameOffset> actual_ptr;
+};
 
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_OFFSET_H_

--- a/src/game_address_locator/c/game_ordinal.h
+++ b/src/game_address_locator/c/game_ordinal.h
@@ -36,23 +36,15 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_ORDINAL_H_
+#define SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_ORDINAL_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../../include/game_address_locator/game_ordinal.h"
 
-namespace sgd2mapi {
+#include <memory>
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
+struct SGD2MAPI_GameOrdinal {
+  std::shared_ptr<sgd2mapi::GameOrdinal> actual_ptr;
+};
 
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_GAME_ADDRESS_LOCATOR_C_GAME_ORDINAL_H_

--- a/src/game_address_locator/game_offset.cc
+++ b/src/game_address_locator/game_offset.cc
@@ -39,8 +39,12 @@
 #include "../../include/game_address_locator/game_offset.h"
 
 #include <cstdint>
+#include <memory>
 
 #include "../../include/game_address_locator/game_address_locator_interface.h"
+
+#include "c/game_address_locator_interface.h"
+#include "c/game_offset.h"
 
 namespace sgd2mapi {
 
@@ -73,49 +77,70 @@ std::intptr_t GameOffset::offset() const noexcept {
  * C Interface
  */
 
-void SGD2MAPI_GameOffset_CreateAsGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface* dest,
+struct SGD2MAPI_GameOffset*
+SGD2MAPI_GameOffset_Create(
     std::intptr_t offset
 ) {
-  struct SGD2MAPI_GameOffset game_offset;
-  SGD2MAPI_GameOffset_CreateAsGameOffset(
-      &game_offset,
-      offset
-  );
+  struct SGD2MAPI_GameOffset* c_game_offset = new SGD2MAPI_GameOffset;
+  c_game_offset->actual_ptr =
+      std::make_shared<sgd2mapi::GameOffset>(
+          offset
+      );
 
-  SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterface(
-      dest,
-      &game_offset
-  );
+  return c_game_offset;
 }
 
-void SGD2MAPI_GameOffset_CreateAsGameOffset(
-    struct SGD2MAPI_GameOffset* dest,
+struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOffset_CreateAsGameAddressLocatorInterface(
     std::intptr_t offset
 ) {
-  dest->game_offset = new sgd2mapi::GameOffset(offset);
+  struct SGD2MAPI_GameAddressLocatorInterface*
+      c_game_address_locator_interface =
+          new SGD2MAPI_GameAddressLocatorInterface;
+
+  c_game_address_locator_interface->actual_ptr =
+      std::make_shared<sgd2mapi::GameOffset>(
+          offset
+      );
+
+  return c_game_address_locator_interface;
 }
 
-void SGD2MAPI_GameOffset_Destroy(
-    struct SGD2MAPI_GameOffset* game_offset
+void
+SGD2MAPI_GameOffset_Destroy(
+    struct SGD2MAPI_GameOffset* c_game_offset
 ) {
-  sgd2mapi::GameOffset* actual_game_offset =
-      static_cast<sgd2mapi::GameOffset*>(game_offset->game_offset);
-
-  delete actual_game_offset;
+  delete c_game_offset;
 }
 
-void SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface* dest,
-    const struct SGD2MAPI_GameOffset* game_offset
+struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterface(
+    const struct SGD2MAPI_GameOffset* c_game_offset
 ) {
-  dest->game_address_locator_interface = game_offset->game_offset;
+  struct SGD2MAPI_GameAddressLocatorInterface*
+      c_game_address_locator_interface =
+          new SGD2MAPI_GameAddressLocatorInterface;
+  c_game_address_locator_interface->actual_ptr = c_game_offset->actual_ptr;
+
+  return c_game_address_locator_interface;
 }
 
-std::intptr_t SGD2MAPI_GameOffset_GetOffset(
-    const struct SGD2MAPI_GameOffset* game_offset
+struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOffset_UpcastToGameAddressLocatorInterfaceThenDestroy(
+    struct SGD2MAPI_GameOffset* c_game_offset
 ) {
-  const sgd2mapi::GameOffset* actual_game_offset =
-      static_cast<const sgd2mapi::GameOffset*>(game_offset->game_offset);
-  return actual_game_offset->offset();
+  struct SGD2MAPI_GameAddressLocatorInterface*
+      c_game_address_locator_interface =
+          new SGD2MAPI_GameAddressLocatorInterface;
+
+  SGD2MAPI_GameOffset_Destroy(c_game_offset);
+
+  return c_game_address_locator_interface;
+}
+
+std::intptr_t
+SGD2MAPI_GameOffset_GetOffset(
+    const struct SGD2MAPI_GameOffset* c_game_offset
+) {
+  return c_game_offset->actual_ptr->offset();
 }

--- a/src/game_address_locator/game_ordinal.cc
+++ b/src/game_address_locator/game_ordinal.cc
@@ -41,10 +41,14 @@
 #include <windows.h>
 #include <cstdint>
 #include <cstdlib>
+#include <memory>
 #include <string>
 
 #include <boost/format.hpp>
 #include "../../include/game_address_locator/game_address_locator_interface.h"
+
+#include "c/game_address_locator_interface.h"
+#include "c/game_ordinal.h"
 
 namespace sgd2mapi {
 
@@ -108,50 +112,69 @@ int GameOrdinal::ordinal() const noexcept {
  * C Interface
  */
 
-void SGD2MAPI_GameOrdinal_CreateAsGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface* dest,
+struct SGD2MAPI_GameOrdinal*
+SGD2MAPI_GameOrdinal_Create(
     int ordinal
 ) {
-  struct SGD2MAPI_GameOrdinal game_ordinal;
-  SGD2MAPI_GameOrdinal_CreateAsGameOrdinal(
-      &game_ordinal,
-      ordinal
-  );
+  struct SGD2MAPI_GameOrdinal* c_game_ordinal = new SGD2MAPI_GameOrdinal;
+  c_game_ordinal->actual_ptr =
+      std::make_shared<sgd2mapi::GameOrdinal>(ordinal);
 
-  SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterface(
-      dest,
-      &game_ordinal
-  );
+  return c_game_ordinal;
 }
 
-void SGD2MAPI_GameOrdinal_CreateAsGameOrdinal(
-    struct SGD2MAPI_GameOrdinal* dest,
+struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOrdinal_CreateAsGameAddressLocatorInterface(
     int ordinal
 ) {
-  dest->game_ordinal = new sgd2mapi::GameOrdinal(ordinal);
+  struct SGD2MAPI_GameAddressLocatorInterface*
+      c_game_address_locator_interface =
+          new SGD2MAPI_GameAddressLocatorInterface;
+
+  c_game_address_locator_interface->actual_ptr =
+      std::make_shared<sgd2mapi::GameOrdinal>(ordinal);
+
+  return c_game_address_locator_interface;
 }
 
 void SGD2MAPI_GameOrdinal_Destroy(
-    struct SGD2MAPI_GameOrdinal* game_ordinal
+    struct SGD2MAPI_GameOrdinal* c_game_ordinal
 ) {
-  sgd2mapi::GameOrdinal* actual_game_ordinal =
-      static_cast<sgd2mapi::GameOrdinal*>(game_ordinal->game_ordinal);
-
-  delete actual_game_ordinal;
+  delete c_game_ordinal;
 }
 
-void SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterface(
-    struct SGD2MAPI_GameAddressLocatorInterface* dest,
-    const struct SGD2MAPI_GameOrdinal* game_ordinal
+struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterface(
+    const struct SGD2MAPI_GameOrdinal* c_game_ordinal
 ) {
-  dest->game_address_locator_interface = game_ordinal->game_ordinal;
+  struct SGD2MAPI_GameAddressLocatorInterface*
+      c_game_address_locator_interface =
+          new SGD2MAPI_GameAddressLocatorInterface;
+
+  c_game_address_locator_interface->actual_ptr =
+      c_game_ordinal->actual_ptr;
+
+  return c_game_address_locator_interface;
 }
 
-int SGD2MAPI_GameOrdinal_GetOrdinal(
-    const struct SGD2MAPI_GameOrdinal* game_ordinal
+struct SGD2MAPI_GameAddressLocatorInterface*
+SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterfaceThenDestroy(
+    struct SGD2MAPI_GameOrdinal* c_game_ordinal
 ) {
-  const sgd2mapi::GameOrdinal* actual_game_ordinal =
-      static_cast<const sgd2mapi::GameOrdinal*>(game_ordinal->game_ordinal);
+  struct SGD2MAPI_GameAddressLocatorInterface*
+      c_game_address_locator_interface =
+          SGD2MAPI_GameOrdinal_UpcastToGameAddressLocatorInterface(
+              c_game_ordinal
+          );
 
-  return actual_game_ordinal->ordinal();
+  SGD2MAPI_GameOrdinal_Destroy(c_game_ordinal);
+
+  return c_game_address_locator_interface;
+}
+
+int
+SGD2MAPI_GameOrdinal_GetOrdinal(
+    const struct SGD2MAPI_GameOrdinal* c_game_ordinal
+) {
+  return c_game_ordinal->actual_ptr->ordinal();
 }

--- a/src/game_patch/c/game_branch_patch.h
+++ b/src/game_patch/c/game_branch_patch.h
@@ -36,23 +36,15 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_GAME_PATCH_C_GAME_BRANCH_PATCH_H_
+#define SGD2MAPI_GAME_PATCH_C_GAME_BRANCH_PATCH_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../../include/game_patch/game_branch_patch.h"
 
-namespace sgd2mapi {
+#include <memory>
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
+struct SGD2MAPI_GameBranchPatch {
+  std::shared_ptr<sgd2mapi::GameBranchPatch> actual_ptr;
+};
 
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_GAME_PATCH_C_GAME_BRANCH_PATCH_H_

--- a/src/game_patch/c/game_buffer_patch.h
+++ b/src/game_patch/c/game_buffer_patch.h
@@ -36,23 +36,15 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_GAME_PATCH_C_GAME_BUFFER_PATCH_H_
+#define SGD2MAPI_GAME_PATCH_C_GAME_BUFFER_PATCH_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../../include/game_patch/game_buffer_patch.h"
 
-namespace sgd2mapi {
+#include <memory>
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
+struct SGD2MAPI_GameBufferPatch {
+  std::shared_ptr<sgd2mapi::GameBufferPatch> actual_ptr;
+};
 
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_GAME_PATCH_C_GAME_BUFFER_PATCH_H_

--- a/src/game_patch/c/game_nop_patch.h
+++ b/src/game_patch/c/game_nop_patch.h
@@ -36,23 +36,13 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_GAME_PATCH_C_GAME_NOP_PATCH_H_
+#define SGD2MAPI_GAME_PATCH_C_GAME_NOP_PATCH_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../../include/game_patch/game_buffer_patch.h"
 
-namespace sgd2mapi {
+struct SGD2MAPI_GameNopPatch {
+  std::shared_ptr<sgd2mapi::GameNopPatch> actual_ptr;
+};
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
-
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_GAME_PATCH_C_GAME_NOP_PATCH_H_

--- a/src/game_patch/c/game_patch_base.h
+++ b/src/game_patch/c/game_patch_base.h
@@ -36,23 +36,15 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "../../include/game_address_locator/game_address_locator_interface.h"
+#ifndef SGD2MAPI_GAME_PATCH_C_GAME_PATCH_BASE_H_
+#define SGD2MAPI_GAME_PATCH_C_GAME_PATCH_BASE_H_
 
-#include "c/game_address_locator_interface.h"
+#include "../../../include/game_patch/game_patch_base.h"
 
-namespace sgd2mapi {
+#include <memory>
 
-GameAddressLocatorInterface::~GameAddressLocatorInterface() noexcept = default;
+struct SGD2MAPI_GamePatchBase {
+  std::shared_ptr<sgd2mapi::GamePatchBase> actual_ptr;
+};
 
-} // namespace sgd2mapi
-
-/**
- * C Interface
- */
-
-void SGD2MAPI_GameAddressLocatorInterface_Destroy(
-    struct SGD2MAPI_GameAddressLocatorInterface*
-        c_game_address_locator_interface
-) {
-  delete c_game_address_locator_interface;
-}
+#endif // SGD2MAPI_GAME_PATCH_C_GAME_PATCH_BASE_H_

--- a/src/game_patch/game_patch_base.cc
+++ b/src/game_patch/game_patch_base.cc
@@ -42,8 +42,11 @@
 #include <cstdint>
 #include <cstdlib>
 #include <utility>
+#include <vector>
 
 #include "../../include/game_address.h"
+
+#include "c/game_patch_base.h"
 
 namespace sgd2mapi {
 
@@ -180,29 +183,23 @@ std::size_t GamePatchBase::patch_size() const noexcept {
  * C Interface
  */
 
-void SGD2MAPI_GamePatchBase_Destroy(
-    struct SGD2MAPI_GamePatchBase* game_patch_base
+void
+SGD2MAPI_GamePatchBase_Destroy(
+    struct SGD2MAPI_GamePatchBase* c_game_patch_base
 ) {
-  sgd2mapi::GamePatchBase* actual_game_patch_base =
-      static_cast<sgd2mapi::GamePatchBase*>(game_patch_base->game_patch_base);
-
-  delete actual_game_patch_base;
+  delete c_game_patch_base;
 }
 
-void SGD2MAPI_GamePatchBase_Apply(
-    struct SGD2MAPI_GamePatchBase* game_patch_base
+void
+SGD2MAPI_GamePatchBase_Apply(
+    struct SGD2MAPI_GamePatchBase* c_game_patch_base
 ) {
-  sgd2mapi::GamePatchBase* actual_game_patch_base =
-      static_cast<sgd2mapi::GamePatchBase*>(game_patch_base->game_patch_base);
-
-  actual_game_patch_base->Apply();
+  c_game_patch_base->actual_ptr->Apply();
 }
 
-void SGD2MAPI_GamePatchBase_Remove(
-    struct SGD2MAPI_GamePatchBase* game_patch_base
+void
+SGD2MAPI_GamePatchBase_Remove(
+    struct SGD2MAPI_GamePatchBase* c_game_patch_base
 ) {
-  sgd2mapi::GamePatchBase* actual_game_patch_base =
-      static_cast<sgd2mapi::GamePatchBase*>(game_patch_base->game_patch_base);
-
-  actual_game_patch_base->Remove();
+  c_game_patch_base->actual_ptr->Remove();
 }


### PR DESCRIPTION
In order to be consistent with how the C interface will function for D2
structs, all C interface code has been redesigned to revolve around
returning a pointers to new objects on creation.