### PR TITLE
Redo Address Table

### DIFF
--- a/include/game_address_locator/game_decorated_name.h
+++ b/include/game_address_locator/game_decorated_name.h
@@ -63,12 +63,12 @@ class DLLEXPORT GameDecoratedName : public GameAddressLocatorInterface {
   explicit GameDecoratedName(std::string_view decorated_name);
 
   GameDecoratedName(const GameDecoratedName&);
-  GameDecoratedName(GameDecoratedName&&);
+  GameDecoratedName(GameDecoratedName&&) noexcept;
 
   ~GameDecoratedName() override;
 
   GameDecoratedName& operator=(const GameDecoratedName&);
-  GameDecoratedName& operator=(GameDecoratedName&&);
+  GameDecoratedName& operator=(GameDecoratedName&&) noexcept;
 
   std::intptr_t ResolveGameAddress(std::intptr_t base_address)
       const noexcept override;

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -38,7 +38,6 @@
 
 #include "config_parser.h"
 
-#include <fstream>
 #include <string>
 #include <string_view>
 
@@ -126,17 +125,19 @@ void AddMissingConfigEntries(nlohmann::json& config_json) noexcept {
   }
 }
 
-nlohmann::json ParseConfig(std::string_view config_path) noexcept {
+nlohmann::json ParseConfig(
+    const boost::filesystem::path& config_path
+) noexcept {
   // Create the config file if it doesn't exist.
-  if (!boost::filesystem::exists(config_path.data())) {
-    std::ofstream config_file(config_path.data());
+  if (!boost::filesystem::exists(config_path)) {
+    boost::filesystem::ofstream config_file(config_path);
     config_file << "{}" << std::endl;
   }
 
   // Read the config file, if read permissions are enabled, for processing.
   nlohmann::json config_json;
 
-  if (std::ifstream config_file(config_path.data());
+  if (boost::filesystem::ifstream config_file(config_path);
       config_file.good()) {
     config_json = nlohmann::json::parse(config_file);
   }
@@ -144,7 +145,7 @@ nlohmann::json ParseConfig(std::string_view config_path) noexcept {
   AddMissingConfigEntries(config_json);
 
   // Write to the config file any new default values.
-  if (std::ofstream config_file(config_path.data());
+  if (boost::filesystem::ofstream config_file(config_path);
       config_file.good()) {
     config_file << config_json << std::endl;
   }
@@ -154,22 +155,27 @@ nlohmann::json ParseConfig(std::string_view config_path) noexcept {
 
 } // namespace
 
-ConfigParser::ConfigParser(std::string_view config_path) noexcept
+ConfigParser::ConfigParser(
+    const boost::filesystem::path& config_path
+) noexcept
     : config_path_(config_path) {
   nlohmann::json main_entry = ParseConfig(config_path);
-  address_table_path_ = main_entry.at(kAddressTablePathKey.data());
+  address_table_path_ =
+      main_entry.at(kAddressTablePathKey.data()).get<std::string>();
 }
 
 ConfigParser& ConfigParser::GetInstance() noexcept {
-  static ConfigParser instance(kConfigPath);
+  static ConfigParser instance(kConfigPath.data());
   return instance;
 }
 
-std::string_view ConfigParser::address_table_path() const noexcept {
+const boost::filesystem::path&
+ConfigParser::address_table_path() const noexcept {
   return address_table_path_;
 }
 
-std::string_view ConfigParser::config_path() const noexcept {
+const boost::filesystem::path&
+ConfigParser::config_path() const noexcept {
   return config_path_;
 }
 

--- a/src/config_parser.cc
+++ b/src/config_parser.cc
@@ -66,8 +66,8 @@ constexpr std::string_view kMinorVersionBKey = "Minor Version B";
 constexpr int kMinorVersionBValue = 0;
 
 constexpr std::string_view kAddressTablePathKey =
-    "Address Table Path";
-constexpr std::string_view kDefaultAddressTablePath = "./AddressTable.json";
+    "Address Table Directory Path";
+constexpr std::string_view kDefaultAddressTableDirectory = "Address Table";
 
 void AddMissingConfigEntries(nlohmann::json& config_json) noexcept {
   auto& main_entry = config_json[kMainEntryKey.data()];
@@ -122,7 +122,7 @@ void AddMissingConfigEntries(nlohmann::json& config_json) noexcept {
   // Add missing values.
   if (auto& entry = main_entry[kAddressTablePathKey.data()];
       !entry.is_string()) {
-    entry = kDefaultAddressTablePath;
+    entry = kDefaultAddressTableDirectory;
   }
 }
 

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -42,6 +42,8 @@
 #include <string>
 #include <string_view>
 
+#include <boost/filesystem.hpp>
+
 namespace sgd2mapi {
 
 constexpr std::string_view kConfigPath = "./SlashGaming-Config.json";
@@ -56,14 +58,14 @@ class ConfigParser {
 
   static ConfigParser& GetInstance() noexcept;
 
-  std::string_view config_path() const noexcept;
-  std::string_view address_table_path() const noexcept;
+  const boost::filesystem::path& config_path() const noexcept;
+  const boost::filesystem::path& address_table_path() const noexcept;
 
  private:
-  ConfigParser(std::string_view config_path) noexcept;
+  ConfigParser(const boost::filesystem::path& config_path) noexcept;
 
-  std::string config_path_;
-  std::string address_table_path_;
+  boost::filesystem::path config_path_;
+  boost::filesystem::path address_table_path_;
 };
 
 } // namespace sgd2mapi

--- a/src/game_address.cc
+++ b/src/game_address.cc
@@ -99,8 +99,8 @@ std::intptr_t ResolveGameAddress(
         running_address_locator->ResolveGameAddress(base_address);
   } catch (std::out_of_range&) {
     std::wstring error_message = (boost::wformat(
-        L"Game address not defined for the game version: %s. The game will "
-        L"nowexit.") % GetRunningGameVersionName().data()).str();
+        L"Game address not defined for the game version: %s"
+    )% GetRunningGameVersionName().data()).str();
     MessageBoxW(
         nullptr,
         error_message.data(),

--- a/src/game_address_locator/game_decorated_name.cc
+++ b/src/game_address_locator/game_decorated_name.cc
@@ -58,7 +58,7 @@ GameDecoratedName::GameDecoratedName(std::string_view decorated_name)
 
 GameDecoratedName::GameDecoratedName(const GameDecoratedName&) = default;
 
-GameDecoratedName::GameDecoratedName(GameDecoratedName&&) = default;
+GameDecoratedName::GameDecoratedName(GameDecoratedName&&) noexcept = default;
 
 GameDecoratedName::~GameDecoratedName() = default;
 
@@ -66,7 +66,9 @@ GameDecoratedName& GameDecoratedName::operator=(
     const GameDecoratedName&
 ) = default;
 
-GameDecoratedName& GameDecoratedName::operator=(GameDecoratedName&&) = default;
+GameDecoratedName& GameDecoratedName::operator=(
+    GameDecoratedName&&
+) noexcept = default;
 
 std::intptr_t GameDecoratedName::ResolveGameAddress(
     std::intptr_t base_address

--- a/src/game_address_table.cc
+++ b/src/game_address_table.cc
@@ -39,7 +39,6 @@
 #include "game_address_table.h"
 
 #include <cstdint>
-#include <fstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -61,11 +60,11 @@ GameAddressTable::GameAddressTable(const boost::filesystem::path& table_path)
 }
 
 const GameAddressTable& GameAddressTable::GetInstance() {
-  std::string_view address_table_directory =
+  const boost::filesystem::path& address_table_directory =
       ConfigParser::GetInstance().address_table_path();
   std::string_view running_game_version_name = GetRunningGameVersionName();
 
-  boost::filesystem::path table_file(address_table_directory.data());
+  boost::filesystem::path table_file(address_table_directory);
   table_file /= running_game_version_name.data();
   table_file += ".txt";
 

--- a/src/game_address_table.cc
+++ b/src/game_address_table.cc
@@ -56,13 +56,21 @@
 
 namespace sgd2mapi {
 
-GameAddressTable::GameAddressTable(std::string_view table_path)
+GameAddressTable::GameAddressTable(const boost::filesystem::path& table_path)
     : address_table_(ReadTsvTableFile(table_path)) {
 }
 
 const GameAddressTable& GameAddressTable::GetInstance() {
+  std::string_view address_table_directory =
+      ConfigParser::GetInstance().address_table_path();
+  std::string_view running_game_version_name = GetRunningGameVersionName();
+
+  boost::filesystem::path table_file(address_table_directory.data());
+  table_file /= running_game_version_name.data();
+  table_file += ".txt";
+
   static GameAddressTable instance(
-      ConfigParser::GetInstance().address_table_path()
+      table_file
   );
   return instance;
 }

--- a/src/game_address_table.h
+++ b/src/game_address_table.h
@@ -44,6 +44,7 @@
 #include <string_view>
 #include <unordered_map>
 
+#include <boost/filesystem.hpp>
 #include "../include/game_address.h"
 
 namespace sgd2mapi {
@@ -61,7 +62,7 @@ class GameAddressTable {
  private:
   std::unordered_map<std::string, std::intptr_t> address_table_;
 
-  explicit GameAddressTable(std::string_view table_path);
+  explicit GameAddressTable(const boost::filesystem::path& table_path);
   static const GameAddressTable& GetInstance();
 };
 

--- a/src/game_address_table_reader.cc
+++ b/src/game_address_table_reader.cc
@@ -80,8 +80,8 @@ ResolveLocatorAndGetAddress(
   } else if (locator_type == kLocatorTypeOrdinal) {
     int ordinal;
     std::from_chars(
-        &locator_value.front(),
-        &locator_value.back(),
+        locator_value.data(),
+        locator_value.data() + locator_value.length(),
         ordinal
     );
 
@@ -117,7 +117,6 @@ ResolveAddress(
 }
 
 } // namespace
-
 
 std::unordered_map<std::string, std::intptr_t>
 ReadTsvTableFile(

--- a/src/game_address_table_reader.cc
+++ b/src/game_address_table_reader.cc
@@ -1,0 +1,228 @@
+/**
+ * SlashGaming Diablo II Modding API
+ * Copyright (C) 2018  SlashGaming Community
+ *
+ * This file is part of SlashGaming Diablo II Modding API.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game, provided that the game or its libraries do not link to this
+ *  Program.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Glide wrapper (or a modified version of that library),
+ *  containing parts not covered by a compatible license, provided that the
+ *  wrapper does not link to this Program, the licensors of this Program
+ *  grant you additional permission to convey the resulting work.
+ */
+
+#include "game_address_table_reader.h"
+
+#include <cstdint>
+#include <charconv>
+#include <fstream>
+#include <regex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <nlohmann/json.hpp>
+#include "../include/game_address_locator.h"
+#include "../include/game_library.h"
+#include "game_library_table.h"
+#include "../include/game_version.h"
+
+namespace sgd2mapi {
+
+namespace {
+
+constexpr std::string_view kLocatorTypeKey = "Locator Type";
+constexpr std::string_view kLocatorValueKey = "Locator Value";
+
+constexpr std::string_view kLocatorTypeOffset = "Offset";
+constexpr std::string_view kLocatorTypeOrdinal = "Ordinal";
+constexpr std::string_view kLocatorTypeDecoratedName = "Decorated Name";
+
+using Locator = std::unordered_map<std::string, nlohmann::json>;
+using LocatorByVersion = std::unordered_map<std::string, Locator>;
+
+std::intptr_t
+ResolveLocatorAndGetAddress(
+    std::intptr_t game_library_base_address,
+    std::string_view locator_type,
+    std::string_view locator_value
+) {
+  std::unique_ptr<GameAddressLocatorInterface> game_address_locator;
+
+  if (locator_type == kLocatorTypeOffset) {
+    int offset = std::stoi(locator_value.data(), 0, 16);
+    game_address_locator = std::make_unique<GameOffset>(offset);
+  } else if (locator_type == kLocatorTypeOrdinal) {
+    int ordinal;
+    std::from_chars(
+        &locator_value.front(),
+        &locator_value.back(),
+        ordinal
+    );
+
+    game_address_locator = std::make_unique<GameOrdinal>(ordinal);
+  } else if (locator_type == kLocatorTypeDecoratedName) {
+    game_address_locator = std::make_unique<GameDecoratedName>(locator_value);
+  }
+
+  return game_address_locator->ResolveGameAddress(game_library_base_address);
+}
+
+std::intptr_t
+ResolveAddress(
+    std::string_view library_name,
+    std::string_view address_name,
+    std::string_view locator_type,
+    std::string_view locator_value
+) {
+  std::string library_file_name = library_name.data();
+  library_file_name += ".dll";
+
+  const GameLibrary& game_library =
+      GameLibraryTable::GetInstance().GetGameLibrary(library_file_name);
+  std::intptr_t game_library_base_address = game_library.base_address();
+
+  std::intptr_t resolved_game_address = ResolveLocatorAndGetAddress(
+      game_library_base_address,
+      locator_type,
+      locator_value
+  );
+
+  return resolved_game_address;
+}
+
+} // namespace
+
+
+std::unordered_map<std::string, std::intptr_t>
+ReadTsvTableFile(
+    std::string_view table_file_path
+) {
+  static const std::regex kLineRegex(
+      "(.*?)\t(.*?)\t(.*?)\t([^\t]*)(.*)",
+      std::regex_constants::ECMAScript | std::regex::icase
+  );
+
+  std::unordered_map<std::string, std::intptr_t> address_table;
+
+  // Open the file and check for it to be valid.
+  std::ifstream address_table_file_stream(table_file_path.data());
+
+  if (!address_table_file_stream) {
+    return address_table;
+  }
+
+  // Discard the header line, because it's for humans.
+  address_table_file_stream.ignore(
+      std::numeric_limits<std::streamsize>::max(),
+      '\n'
+  );
+
+  // Read each line.
+  for (std::string line; std::getline(address_table_file_stream, line); ) {
+    std::smatch matches;
+    if (!std::regex_match(line.cbegin(), line.cend(), matches, kLineRegex)) {
+      continue;
+    }
+
+    // Pull the column data.
+    const std::string& library_name = matches[1];
+    const std::string& address_name = matches[2];
+    const std::string& locator_type = matches[3];
+    const std::string& locator_value = matches[4];
+
+    std::intptr_t resolved_game_address = ResolveAddress(
+        library_name,
+        address_name,
+        locator_type,
+        locator_value
+    );
+
+    std::string full_address_name = library_name + "_" + address_name;
+
+    address_table.insert_or_assign(
+        std::move(full_address_name),
+        resolved_game_address
+    );
+  }
+
+  return address_table;
+}
+
+std::unordered_map<std::string, std::intptr_t>
+ReadJsonTableFile(
+    std::string_view table_file_path
+) {
+  // Read the address table into JSON.
+  nlohmann::json address_table_json;
+  if (std::ifstream address_table_file(table_file_path.data());
+      address_table_file.good()) {
+    address_table_json = nlohmann::json::parse(address_table_file);
+  }
+
+  // Parse the JSON into the address table.
+  std::unordered_map<std::string, std::intptr_t> address_table;
+
+  std::string_view version_name = GetRunningGameVersionName();
+  for (const auto& library_items : address_table_json.items()) {
+    const std::string library_name = library_items.key();
+    const std::string library_path = library_name + ".dll";
+    const GameLibrary& game_library =
+        GameLibraryTable::GetInstance().GetGameLibrary(library_path);
+    std::intptr_t base_address = game_library.base_address();
+
+    for (const auto& item : library_items.value().items()) {
+      std::string game_address_name = item.key();
+
+      // Determine the destination game address.
+      LocatorByVersion locator_by_version = item.value();
+      Locator locator = locator_by_version.at(version_name.data());
+
+      std::string locator_type = locator.at(kLocatorTypeKey.data());
+      std::string locator_value = locator.at(kLocatorValueKey.data());
+
+      std::intptr_t resolved_game_address = ResolveLocatorAndGetAddress(
+          base_address,
+          locator_type,
+          locator_value
+      );
+
+      // Determine the full game address name.
+      std::string full_address_name = library_name + "_" + game_address_name;
+
+      address_table.insert_or_assign(
+          std::move(full_address_name),
+          resolved_game_address
+      );
+    }
+  }
+
+  return address_table;
+}
+
+} // namespace sgd2mapi

--- a/src/game_address_table_reader.cc
+++ b/src/game_address_table_reader.cc
@@ -48,6 +48,7 @@
 #include <unordered_map>
 
 #include <boost/filesystem.hpp>
+#include <boost/format.hpp>
 #include "../include/game_address_locator.h"
 #include "../include/game_library.h"
 #include "game_library_table.h"
@@ -125,15 +126,23 @@ ReadTsvTableFile(
       std::regex_constants::ECMAScript | std::regex::icase
   );
 
-  std::unordered_map<std::string, std::intptr_t> address_table;
-
   // Open the file and check for it to be valid.
   boost::filesystem::ifstream address_table_file_stream(
       table_file_path
   );
 
   if (!address_table_file_stream) {
-    return address_table;
+    std::wstring error_message = (boost::wformat(
+        L"The address table located at %s could not be found."
+    ) % table_file_path.c_str()).str();
+
+    MessageBoxW(
+        nullptr,
+        error_message.data(),
+        L"Could Not Locate Address Table",
+        MB_OK | MB_ICONERROR
+    );
+    std::exit(0);
   }
 
   // Discard the header line, because it's for humans.
@@ -141,6 +150,8 @@ ReadTsvTableFile(
       std::numeric_limits<std::streamsize>::max(),
       '\n'
   );
+
+  std::unordered_map<std::string, std::intptr_t> address_table;
 
   // Read each line.
   for (std::string line; std::getline(address_table_file_stream, line); ) {

--- a/src/game_address_table_reader.cc
+++ b/src/game_address_table_reader.cc
@@ -38,14 +38,16 @@
 
 #include "game_address_table_reader.h"
 
+#include <windows.h>
 #include <cstdint>
+#include <cstdlib>
 #include <charconv>
-#include <fstream>
 #include <regex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
+#include <boost/filesystem.hpp>
 #include "../include/game_address_locator.h"
 #include "../include/game_library.h"
 #include "game_library_table.h"
@@ -116,7 +118,7 @@ ResolveAddress(
 
 std::unordered_map<std::string, std::intptr_t>
 ReadTsvTableFile(
-    std::string_view table_file_path
+    const boost::filesystem::path& table_file_path
 ) {
   static const std::regex kLineRegex(
       "(.*?)\t(.*?)\t(.*?)\t([^\t]*)(.*)",
@@ -126,7 +128,9 @@ ReadTsvTableFile(
   std::unordered_map<std::string, std::intptr_t> address_table;
 
   // Open the file and check for it to be valid.
-  std::ifstream address_table_file_stream(table_file_path.data());
+  boost::filesystem::ifstream address_table_file_stream(
+      table_file_path
+  );
 
   if (!address_table_file_stream) {
     return address_table;

--- a/src/game_address_table_reader.h
+++ b/src/game_address_table_reader.h
@@ -49,11 +49,6 @@ ReadTsvTableFile(
     std::string_view file_path
 );
 
-std::unordered_map<std::string, std::intptr_t>
-ReadJsonTableFile(
-    std::string_view file_path
-);
-
 } // namespace sgd2mapi
 
 #endif // SGD2MAPI_GAME_ADDRESS_TABLE_READER_TSV_GAME_ADDRESS_TABLE_READER_H_

--- a/src/game_address_table_reader.h
+++ b/src/game_address_table_reader.h
@@ -39,14 +39,17 @@
 #ifndef SGD2MAPI_GAME_ADDRESS_TABLE_READER_H_
 #define SGD2MAPI_GAME_ADDRESS_TABLE_READER_H_
 
-#include <string_view>
+#include <cstdint>
+#include <string>
 #include <unordered_map>
+
+#include <boost/filesystem.hpp>
 
 namespace sgd2mapi {
 
 std::unordered_map<std::string, std::intptr_t>
 ReadTsvTableFile(
-    std::string_view file_path
+    const boost::filesystem::path& file_path
 );
 
 } // namespace sgd2mapi

--- a/src/game_address_table_reader.h
+++ b/src/game_address_table_reader.h
@@ -36,39 +36,24 @@
  *  grant you additional permission to convey the resulting work.
  */
 
-#include "game_address_table.h"
+#ifndef SGD2MAPI_GAME_ADDRESS_TABLE_READER_H_
+#define SGD2MAPI_GAME_ADDRESS_TABLE_READER_H_
 
-#include <cstdint>
-#include <fstream>
-#include <string>
 #include <string_view>
 #include <unordered_map>
 
-#include <boost/filesystem.hpp>
-#include <nlohmann/json.hpp>
-
-#include "config_parser.h"
-#include "../include/game_address_locator.h"
-#include "game_address_table_reader.h"
-#include "../include/game_library.h"
-#include "game_library_table.h"
-#include "../include/game_version.h"
-
 namespace sgd2mapi {
 
-GameAddressTable::GameAddressTable(std::string_view table_path)
-    : address_table_(ReadTsvTableFile(table_path)) {
-}
+std::unordered_map<std::string, std::intptr_t>
+ReadTsvTableFile(
+    std::string_view file_path
+);
 
-const GameAddressTable& GameAddressTable::GetInstance() {
-  static GameAddressTable instance(
-      ConfigParser::GetInstance().address_table_path()
-  );
-  return instance;
-}
-
-std::intptr_t GameAddressTable::GetAddress(std::string_view address_name) {
-  return GetInstance().address_table_.at(address_name.data());
-}
+std::unordered_map<std::string, std::intptr_t>
+ReadJsonTableFile(
+    std::string_view file_path
+);
 
 } // namespace sgd2mapi
+
+#endif // SGD2MAPI_GAME_ADDRESS_TABLE_READER_TSV_GAME_ADDRESS_TABLE_READER_H_


### PR DESCRIPTION
Address tables are read using one file, which is in JSON format.  Instead of storing all of the information in a non-compact way, this change will make the address tables read from tab-delimited format files.  One file is for each version.

The table reading code is also separated from the address table.

Some usage of boost::filesystem was not taken advantage of as well, so this change also increases its usage.