### PR TITLE
Add default library include files

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data.h
@@ -38,8 +38,24 @@
 #ifndef SGD2MAPI_C_GAME_DATA_H_
 #define SGD2MAPI_C_GAME_DATA_H_
 
+#include "game_data/bnclient_data.h"
 #include "game_data/d2client_data.h"
+#include "game_data/d2cmp_data.h"
+#include "game_data/d2common_data.h"
+#include "game_data/d2ddraw_data.h"
+#include "game_data/d2direct3d_data.h"
+#include "game_data/d2game_data.h"
+#include "game_data/d2gdi_data.h"
 #include "game_data/d2gfx_data.h"
+#include "game_data/d2glide_data.h"
+#include "game_data/d2lang_data.h"
+#include "game_data/d2launch_data.h"
+#include "game_data/d2mcpclient_data.h"
+#include "game_data/d2multi_data.h"
+#include "game_data/d2net_data.h"
+#include "game_data/d2sound_data.h"
+#include "game_data/fog_data.h"
+#include "game_data/storm_data.h"
 #include "game_data/d2win_data.h"
 
 #endif // SGD2MAPI_C_GAME_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/bnclient_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/bnclient_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_BNCLIENT_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_BNCLIENT_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_BNCLIENT_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2cmp_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2cmp_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2CMP_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2CMP_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2CMP_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2common_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2common_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2COMMON_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2COMMON_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2COMMON_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2game_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2game_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2GAME_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2GAME_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2GAME_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2glide_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2glide_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2GLIDE_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2GLIDE_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2GLIDE_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2lang_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2lang_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2LANG_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2LANG_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2LANG_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2launch_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2launch_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2LAUNCH_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2LAUNCH_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2LAUNCH_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2mcpclient_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2mcpclient_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2MCPCLIENT_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2MCPCLIENT_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2MCPCLIENT_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2multi_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2multi_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2MULTI_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2MULTI_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2MULTI_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2net_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2net_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2NET_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2NET_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2NET_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2sound_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2sound_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2SOUND_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_D2SOUND_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_D2SOUND_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/fog_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/fog_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_FOG_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_FOG_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_FOG_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/storm_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/storm_data.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_DATA_STORM_DATA_H_
+#define SGD2MAPI_C_GAME_DATA_STORM_DATA_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_DATA_STORM_DATA_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/bnclient_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/bnclient_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_BNCLIENT_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_BNCLIENT_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_BNCLIENT_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2client_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2client_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2CLIENT_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2CLIENT_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2CLIENT_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2cmp_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2cmp_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2CMP_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2CMP_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2CMP_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2common_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2common_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2COMMON_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2COMMON_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2COMMON_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2ddraw_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2ddraw_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2DDRAW_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2DDRAW_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2DDRAW_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2direct3d_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2direct3d_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2DIRECT3D_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2DIRECT3D_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2DIRECT3D_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2game_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2game_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2GAME_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2GAME_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2GAME_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2gdi_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2gdi_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2GDI_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2GDI_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2GDI_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2gfx_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2gfx_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2GFX_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2GFX_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2GFX_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2glide_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2glide_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2GLIDE_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2GLIDE_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2GLIDE_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2launch_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2launch_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2LAUNCH_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2LAUNCH_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2LAUNCH_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2mcpclient_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2mcpclient_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2MCPCLIENT_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2MCPCLIENT_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2MCPCLIENT_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2multi_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2multi_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2MULTI_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2MULTI_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2MULTI_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2net_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2net_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2NET_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2NET_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2NET_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2sound_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2sound_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2SOUND_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2SOUND_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2SOUND_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2win_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2win_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/fog_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/fog_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/storm_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/storm_func.h
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+#define SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data.hpp
@@ -38,8 +38,24 @@
 #ifndef SGD2MAPI_CXX_GAME_DATA_HPP_
 #define SGD2MAPI_CXX_GAME_DATA_HPP_
 
+#include "game_data/bnclient_data.hpp"
 #include "game_data/d2client_data.hpp"
+#include "game_data/d2cmp_data.hpp"
+#include "game_data/d2common_func.hpp"
+#include "game_data/d2ddraw_data.hpp"
+#include "game_data/d2direct3d_data.hpp"
+#include "game_data/d2game_data.hpp"
+#include "game_data/d2gdi_data.hpp"
 #include "game_data/d2gfx_data.hpp"
+#include "game_data/d2glide_data.hpp"
+#include "game_data/d2lang_data.hpp"
+#include "game_data/d2launch_data.hpp"
+#include "game_data/d2mcpclient_data.hpp"
+#include "game_data/d2multi_data.hpp"
+#include "game_data/d2net_data.hpp"
+#include "game_data/d2sound_data.hpp"
 #include "game_data/d2win_data.hpp"
+#include "game_data/fog_data.hpp"
+#include "game_data/storm_data.hpp"
 
 #endif // SGD2MAPI_CXX_GAME_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/bnclient_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/bnclient_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_BNCLIENT_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_BNCLIENT_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_BNCLIENT_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2cmp_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2cmp_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2CMP_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2CMP_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2CMP_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2common_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2common_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2COMMON_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2COMMON_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2COMMON_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2game_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2game_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2GAME_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2GAME_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2GAME_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2GDI_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2GDI_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2GDI_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2glide_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2glide_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2GLIDE_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2GLIDE_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2GLIDE_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2lang_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2lang_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2LANG_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2LANG_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2LANG_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2launch_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2launch_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2LAUNCH_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2LAUNCH_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2LAUNCH_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2mcpclient_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2mcpclient_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2MCPCLIENT_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2MCPCLIENT_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2MCPCLIENT_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2multi_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2multi_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2MULTI_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2MULTI_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2MULTI_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2net_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2net_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2NET_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2NET_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2NET_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2sound_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2sound_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2SOUND_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2SOUND_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_D2SOUND_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/fog_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/fog_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_FOG_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_FOG_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_FOG_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/storm_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/storm_data.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_STORM_DATA_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_STORM_DATA_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_DATA_STORM_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func.hpp
@@ -38,4 +38,24 @@
 #ifndef SGD2MAPI_CXX_GAME_FUNC_HPP_
 #define SGD2MAPI_CXX_GAME_FUNC_HPP_
 
+#include "game_func/bnclient_func.hpp"
+#include "game_func/d2client_func.hpp"
+#include "game_func/d2cmp_func.hpp"
+#include "game_func/d2common_func.hpp"
+#include "game_func/d2ddraw_func.hpp"
+#include "game_func/d2direct3d_func.hpp"
+#include "game_func/d2game_func.hpp"
+#include "game_func/d2gdi_func.hpp"
+#include "game_func/d2gfx_func.hpp"
+#include "game_func/d2glide_func.hpp"
+#include "game_func/d2lang_func.hpp"
+#include "game_func/d2launch_func.hpp"
+#include "game_func/d2mcpclient_func.hpp"
+#include "game_func/d2multi_func.hpp"
+#include "game_func/d2net_func.hpp"
+#include "game_func/d2sound_func.hpp"
+#include "game_func/d2win_func.hpp"
+#include "game_func/fog_func.hpp"
+#include "game_func/storm_func.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/bnclient_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/bnclient_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_BNCLIENT_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_BNCLIENT_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_BNCLIENT_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2client_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2client_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2CLIENT_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2CLIENT_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2CLIENT_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2cmp_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2cmp_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2CMP_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2CMP_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2CMP_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2common_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2common_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2COMMON_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2COMMON_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2COMMON_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2ddraw_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2ddraw_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2DDRAW_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2DDRAW_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2DDRAW_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2direct3d_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2direct3d_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2DIRECT3D_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2DIRECT3D_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2DIRECT3D_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2game_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2game_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2GAME_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2GAME_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2GAME_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gdi_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gdi_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2GDI_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2GDI_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2GDI_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gfx_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gfx_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2GFX_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2GFX_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2GFX_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2glide_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2glide_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2GLIDE_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2GLIDE_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2GLIDE_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2launch_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2launch_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LAUNCH_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2LAUNCH_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2LAUNCH_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2mcpclient_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2mcpclient_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2MCPCLIENT_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2MCPCLIENT_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2MCPCLIENT_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2multi_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2multi_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2MULTI_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2MULTI_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2MULTI_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2net_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2net_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2NET_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2NET_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2NET_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2sound_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2sound_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2SOUND_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2SOUND_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2SOUND_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/fog_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/fog_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/storm_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/storm_func.hpp
@@ -35,27 +35,7 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
 
-#include "game_func/bnclient_func.h"
-#include "game_func/d2client_func.h"
-#include "game_func/d2cmp_func.h"
-#include "game_func/d2common_func.h"
-#include "game_func/d2ddraw_func.h"
-#include "game_func/d2direct3d_func.h"
-#include "game_func/d2game_func.h"
-#include "game_func/d2gdi_func.h"
-#include "game_func/d2gfx_func.h"
-#include "game_func/d2glide_func.h"
-#include "game_func/d2lang_func.h"
-#include "game_func/d2launch_func.h"
-#include "game_func/d2mcpclient_func.h"
-#include "game_func/d2multi_func.h"
-#include "game_func/d2net_func.h"
-#include "game_func/d2sound_func.h"
-#include "game_func/d2win_func.h"
-#include "game_func/fog_func.h"
-#include "game_func/storm_func.h"
-
-#endif // SGD2MAPI_C_GAME_FUNC_H_
+#endif // SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_


### PR DESCRIPTION
The default library include files were at first generated when needed. This change adds all of the data and func files for each default library, so they won't have to be generated later.