### PR TITLE
Add UnicodeChar

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_struct.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct.h
@@ -38,4 +38,6 @@
 #ifndef SGD2MAPI_C_GAME_STRUCT_H_
 #define SGD2MAPI_C_GAME_STRUCT_H_
 
+#include "game_struct/unicode_char.h"
+
 #endif // SGD2MAPI_C_GAME_STRUCT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_struct/unicode_char.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct/unicode_char.h
@@ -1,0 +1,50 @@
+/**
+ * SlashGaming Diablo II Modding API
+ * Copyright (C) 2018-2019  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Modding API.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Glide wrapper (or a modified version of that library),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2MAPI_C_GAME_STRUCT_UNICODE_CHAR_H_
+#define SGD2MAPI_C_GAME_STRUCT_UNICODE_CHAR_H_
+
+#include "../../dllexport_define.inc"
+
+struct D2_UnicodeChar;
+
+struct D2_UnicodeChar {
+  unsigned short ch;
+};
+
+#include "../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_STRUCT_UNICODE_CHAR_H_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct.hpp
@@ -38,4 +38,6 @@
 #ifndef SGD2MAPI_CXX_GAME_STRUCT_HPP_
 #define SGD2MAPI_CXX_GAME_STRUCT_HPP_
 
+#include "game_struct/unicode_char.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_STRUCT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/unicode_char.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/unicode_char.hpp
@@ -1,0 +1,59 @@
+/**
+ * SlashGaming Diablo II Modding API
+ * Copyright (C) 2018-2019  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Modding API.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Glide wrapper (or a modified version of that library),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2MAPI_CXX_GAME_STRUCT_UNICODE_CHAR_HPP_
+#define SGD2MAPI_CXX_GAME_STRUCT_UNICODE_CHAR_HPP_
+
+#include "../../dllexport_define.inc"
+
+namespace d2 {
+
+class UnicodeChar;
+
+class DLLEXPORT UnicodeChar {
+ public:
+  UnicodeChar();
+  UnicodeChar(unsigned short ch);
+
+ private:
+  unsigned short ch_;
+};
+
+} // namespace d2
+
+#include "../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_STRUCT_UNICODE_CHAR_HPP_

--- a/SlashGaming-Diablo-II-API/src/c/game_struct/c_unicode_char.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_struct/c_unicode_char.cc
@@ -1,0 +1,40 @@
+/**
+ * SlashGaming Diablo II Modding API
+ * Copyright (C) 2018-2019  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Modding API.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Glide wrapper (or a modified version of that library),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "../../../include/c/game_struct/unicode_char.h"
+
+#include "../../../include/cxx/game_struct/unicode_char.hpp"

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/unicode_char.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/unicode_char.cc
@@ -1,0 +1,49 @@
+/**
+ * SlashGaming Diablo II Modding API
+ * Copyright (C) 2018-2019  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Modding API.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Glide wrapper (or a modified version of that library),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "../../../include/cxx/game_struct/unicode_char.hpp"
+
+namespace d2 {
+
+UnicodeChar::UnicodeChar() : ch_('\0') {
+}
+
+UnicodeChar::UnicodeChar(unsigned short ch) :
+    ch_('\0') {
+}
+
+} // namespace d2

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/unicode_char.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/unicode_char.cc
@@ -37,13 +37,32 @@
 
 #include "../../../include/cxx/game_struct/unicode_char.hpp"
 
-namespace d2 {
+#include <cstdint>
 
-UnicodeChar::UnicodeChar() : ch_('\0') {
+/**
+ * Latest supported version: 1.14D
+ */
+
+namespace d2 {
+namespace {
+
+#pragma pack(push, 1)
+
+/* sizeof: 0x2 */ struct UnicodeChar_1_00 {
+  /* 0x0 */std::uint16_t ch;
+};
+
+#pragma pop
+
+} // namespace
+
+
+UnicodeChar::UnicodeChar() :
+    ch_('\0') {
 }
 
 UnicodeChar::UnicodeChar(unsigned short ch) :
-    ch_('\0') {
+    ch_(ch) {
 }
 
 } // namespace d2


### PR DESCRIPTION
The UnicodeChar is a struct used to abstract the character encoding used for displaying Diablo II text. It is currently unknown what character encoding it actually uses to display text. All strings of UnicodeChar are null-terminated with the zero-value character.

In all versions of Diablo II, it is defined as a 2 byte struct. It consists of a single member, a uint16_t. It is utilized heavily throughout D2Lang.dll and the UnicodeChar member functions are not obfuscated.

It is officially dubbed Unicode by the Diablo II developers, but this moniker lacks does not explicitly tell users whether it is a string or a character. Thus, UnicodeChar was chosen as the name for this API.

The C interface is very simple, as users can call upon the D2Lang functions to manipulate UnicodeChar arrays. However, the C++ interface should be more flexible. There will be plans to support a UnicodeString that conforms with the proper C++ interfaces (namely, char_traits and string).

Lastly, this addition hopes to end the widespread use of wchar_t where UnicodeChar would have been more appropriate.

The following screenshot of the D2Lang.Unicode::isWhitespace function shows that the single member is not only a 16-bit integer, but that it is also unsigned.
![UnicodeChar](https://user-images.githubusercontent.com/26683324/55794764-f71e9f80-5a7a-11e9-8ef8-8663ed44d69d.PNG)