### PR TITLE
Revise Constant API

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_constant/d2_difficulty_level.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_constant/d2_difficulty_level.h
@@ -50,9 +50,9 @@ enum D2_DifficultyLevel {
   DIFFICULTY_HELL
 };
 
-DLLEXPORT int D2_DifficultyLevel_ToInteger(int id);
+DLLEXPORT int D2_DifficultyLevel_ToGameValue(int id);
 
-DLLEXPORT int D2_DifficultyLevel_FromInteger(int value);
+DLLEXPORT int D2_DifficultyLevel_ToAPIValue(int value);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/SlashGaming-Diablo-II-API/include/cxx/game_constant.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_constant.hpp
@@ -38,6 +38,7 @@
 #ifndef SGD2MAPI_CXX_GAME_CONSTANT_HPP_
 #define SGD2MAPI_CXX_GAME_CONSTANT_HPP_
 
+#include "game_constant/d2_constant.hpp"
 #include "game_constant/d2_difficulty_level.hpp"
 
 #endif // SGD2MAPI_CXX_GAME_CONSTANT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_constant.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_constant.hpp
@@ -43,10 +43,10 @@
 namespace d2 {
 
 template <typename ConstantType>
-int ToInteger(ConstantType id);
+int ToGameValue(ConstantType id);
 
 template <typename ConstantType>
-ConstantType FromInteger(int value);
+ConstantType ToAPIValue(int value);
 
 } // namespace d2
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_difficulty_level.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_difficulty_level.hpp
@@ -53,12 +53,12 @@ enum class DifficultyLevel {
 };
 
 extern template DLLEXPORT
-int ToInteger(
+int ToGameValue(
     enum DifficultyLevel id
 );
 
 extern template DLLEXPORT
-enum DifficultyLevel FromInteger(
+enum DifficultyLevel ToAPIValue(
     int value
 );
 

--- a/SlashGaming-Diablo-II-API/src/c/game_constant/c_d2_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_constant/c_d2_difficulty_level.cc
@@ -39,16 +39,16 @@
 
 #include "../../../include/cxx/game_constant/d2_difficulty_level.hpp"
 
-int D2_DifficultyLevel_ToInteger(int id) {
+int D2_DifficultyLevel_ToGameValue(int id) {
   enum d2::DifficultyLevel actual_id =
       static_cast<enum d2::DifficultyLevel>(id);
 
-  return d2::ToInteger(actual_id);
+  return d2::ToGameValue(actual_id);
 }
 
-int D2_DifficultyLevel_FromInteger(int value) {
+int D2_DifficultyLevel_ToAPIValue(int value) {
   enum d2::DifficultyLevel actual_id =
-      d2::FromInteger<enum d2::DifficultyLevel>(value);
+      d2::ToAPIValue<enum d2::DifficultyLevel>(value);
 
   return static_cast<int>(actual_id);
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_constant_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_constant_impl.hpp
@@ -43,7 +43,7 @@
 namespace d2 {
 
 template <typename ConstantType>
-int ToInteger(ConstantType id) {
+int ToGameValue(ConstantType id) {
   static_assert(
       std::is_enum<ConstantType>::value,
       u8"The specified type is not a constant."
@@ -53,7 +53,7 @@ int ToInteger(ConstantType id) {
 }
 
 template <typename ConstantType>
-ConstantType FromInteger(int value) {
+ConstantType ToAPIValue(int value) {
   static_assert(
       std::is_enum<ConstantType>::value,
       u8"The specified type is not a constant."

--- a/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_difficulty_level.cc
@@ -49,12 +49,12 @@
 namespace d2 {
 
 template int
-ToInteger(
+ToGameValue(
     enum DifficultyLevel id
 );
 
 template enum DifficultyLevel
-FromInteger(
+ToAPIValue(
     int value
 );
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_difficulty_level.cc
@@ -70,12 +70,12 @@ enum DifficultyLevel GetDifficultyLevel(void) {
     value = *converted_ptr;
   }
 
-  return FromInteger<enum DifficultyLevel>(value);
+  return ToAPIValue<enum DifficultyLevel>(value);
 }
 
 void SetDifficultyLevel(enum DifficultyLevel value) {
   std::intptr_t ptr = D2Client_DifficultyLevel();
-  int integer_value = ToInteger<enum DifficultyLevel>(value);
+  int integer_value = ToGameValue<enum DifficultyLevel>(value);
 
   enum GameVersion current_game_version = GetRunningGameVersionId();
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_difficulty_level.cc
@@ -64,11 +64,8 @@ enum DifficultyLevel GetDifficultyLevel(void) {
 
   int value;
 
-  if (current_game_version >= GameVersion::k1_00
-      && current_game_version <= GameVersion::kLod1_14D) {
-    std::int8_t* converted_ptr = reinterpret_cast<std::int8_t*>(ptr);
-    value = *converted_ptr;
-  }
+  std::int8_t* converted_ptr = reinterpret_cast<std::int8_t*>(ptr);
+  value = *converted_ptr;
 
   return ToAPIValue<enum DifficultyLevel>(value);
 }


### PR DESCRIPTION
The constant API functions for converting values to and from version-dependent values is unclear. This change renames the constant conversion functions to be more clear on what they do.

In addition, this fixes the lack on include on a file and also remove a version check for a constant value.