### PR TITLE
Add D2Lang_Unicode_strlen

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strlen.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strlen.h
@@ -35,9 +35,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRLEN_H_
+#define SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRLEN_H_
 
-#include "d2lang/d2lang_unicode_strlen.h"
+#include "../../game_struct/d2_unicode_char.h"
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#include "../../../dllexport_define.inc"
+
+DLLEXPORT int D2_D2Lang_Unicode_strlen(const struct D2_UnicodeChar buffer[]);
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRLEN_H_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp
@@ -35,9 +35,18 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRLEN_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRLEN_HPP_
 
-#include "d2lang/d2lang_unicode_strlen.h"
+#include "../../game_struct/d2_unicode_char.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#include "../../../dllexport_define.inc"
+
+namespace d2::d2lang {
+
+DLLEXPORT int Unicode_strlen(const UnicodeChar buffer[]);
+
+} // namespace d2::d2lang
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRLEN_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang_func.hpp
@@ -38,4 +38,6 @@
 #ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
 #define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
 
+#include "d2lang/d2lang_unicode_strlen.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_unicode_char.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_unicode_char.hpp
@@ -102,6 +102,23 @@ class DLLEXPORT UnicodeCharTraits {
   static int length(const UnicodeChar* str);
 };
 
+// Do not derive from std::basic_string, for same reasons as
+// UnicodeCharTraits.
+class DLLEXPORT UnicodeString {
+  using traits_type = UnicodeCharTraits;
+  using value_type = UnicodeChar;
+  using size_type = int;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+
+ public:
+  size_type length() const noexcept;
+  size_type size() const noexcept;
+
+ private:
+  UnicodeString::size_type length_;
+};
+
 } // namespace d2
 
 #include "../../dllexport_undefine.inc"

--- a/SlashGaming-Diablo-II-API/src/asm_x86_macro.h
+++ b/SlashGaming-Diablo-II-API/src/asm_x86_macro.h
@@ -35,9 +35,31 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+/**
+ * Warning: This header should never be used in any public interface!
+ */
 
-#include "d2lang/d2lang_unicode_strlen.h"
+#ifndef SGD2MAPI_ASM_X86_MACRO_H_
+#define SGD2MAPI_ASM_X86_MACRO_H_
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#if defined(_MSC_VER)
+
+#define ASM_X86(...) \
+    __asm { \
+      __VA_ARGS__ \
+    }
+
+#define ASM_X86_FUNC(name) name
+
+#else
+
+#define ASM_X86(...) \
+    asm( \
+        #__VA_ARGS__ \
+    );
+
+#define ASM_X86_FUNC(name) _##name
+
+#endif
+
+#endif /* SGD2MAPI_ASM_X86_MACRO_H_ */

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
@@ -35,9 +35,13 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#include "../../../../include/c/game_func/d2lang/d2lang_unicode_strlen.h"
 
-#include "d2lang/d2lang_unicode_strlen.h"
+#include "../../../../include/c/game_struct/d2_unicode_char.h"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+int D2_D2Lang_Unicode_strlen(const struct D2_UnicodeChar buffer[]) {
+  auto actual_ptr = reinterpret_cast<const d2::UnicodeChar*>(buffer);
+
+  return d2::d2lang::Unicode_strlen(actual_ptr);
+}

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
@@ -35,9 +35,42 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2lang/d2lang_unicode_strlen.h"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_struct/d2_unicode_char.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2lang {
+namespace {
+
+__declspec(naked) std::intptr_t __cdecl
+D2Lang_Unicode_strlen_1_00(std::intptr_t func_ptr, const UnicodeChar* buffer) {
+  ASM_X86(mov ecx, [esp + 8]);
+  ASM_X86(call dword ptr [esp + 4]);
+  ASM_X86(ret);
+}
+
+std::intptr_t D2Lang_Unicode_strlen(void) {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int Unicode_strlen(const UnicodeChar buffer[]) {
+  std::intptr_t ptr = D2Lang_Unicode_strlen();
+
+  return D2Lang_Unicode_strlen_1_00(ptr, buffer);
+}
+
+} // namespace d2::d2lang

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char_traits.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char_traits.cc
@@ -35,74 +35,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_STRUCT_D2_UNICODE_CHAR_HPP_
-#define SGD2MAPI_CXX_GAME_STRUCT_D2_UNICODE_CHAR_HPP_
+#include "../../../include/cxx/game_struct/d2_unicode_char.hpp"
 
-#include <memory>
-
-#include "../../dllexport_define.inc"
+#include "../../../include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp"
 
 namespace d2 {
 
-struct UnicodeChar;
-
-class DLLEXPORT UnicodeChar_ConstWrapper {
- public:
-  UnicodeChar_ConstWrapper() = delete;
-  UnicodeChar_ConstWrapper(const UnicodeChar* ptr) noexcept;
-
-  virtual ~UnicodeChar_ConstWrapper();
-
-  operator const UnicodeChar*() const noexcept;
-
-  virtual const UnicodeChar* Get() const noexcept;
-
-  unsigned short GetChar() const noexcept;
-
- private:
-  const UnicodeChar* ptr_;
-};
-
-class DLLEXPORT UnicodeChar_Wrapper : public UnicodeChar_ConstWrapper {
- public:
-  UnicodeChar_Wrapper() = delete;
-  UnicodeChar_Wrapper(UnicodeChar* ptr) noexcept;
-
-  ~UnicodeChar_Wrapper() override;
-
-  operator UnicodeChar*() const noexcept;
-
-  UnicodeChar* Get() const noexcept override;
-
-  void SetChar(unsigned short ch) noexcept;
-
- private:
-  UnicodeChar* ptr_;
-};
-
-class DLLEXPORT UnicodeChar_API : public UnicodeChar_Wrapper {
- public:
-  UnicodeChar_API();
-  UnicodeChar_API(unsigned short ch);
-
-  UnicodeChar_API(const UnicodeChar_API& other);
-  UnicodeChar_API(UnicodeChar_API&& other) noexcept;
-
-  ~UnicodeChar_API() override;
-
-  UnicodeChar_API& operator=(const UnicodeChar_API& other);
-  UnicodeChar_API& operator=(UnicodeChar_API&& other) noexcept;
-
-  operator unsigned short() const noexcept;
-};
-
-// Do not derive from std::char_traits because of non-conformance with
-// return types.
-class DLLEXPORT UnicodeCharTraits {
-  static int length(const UnicodeChar* str);
-};
+int UnicodeCharTraits::length(const UnicodeChar* str) {
+  return d2lang::Unicode_strlen(str);
+}
 
 } // namespace d2
-
-#include "../../dllexport_undefine.inc"
-#endif // SGD2MAPI_CXX_GAME_STRUCT_D2_UNICODE_CHAR_HPP_

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_string.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_string.cc
@@ -1,0 +1,53 @@
+/**
+ * SlashGaming Diablo II Modding API
+ * Copyright (C) 2018-2019  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Modding API.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Glide wrapper (or a modified version of that library),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "../../../include/cxx/game_struct/d2_unicode_char.hpp"
+
+namespace d2 {
+
+UnicodeString::UnicodeString() {
+}
+
+UnicodeString::size_type UnicodeString::length() const noexcept {
+  return this->length_;
+}
+
+UnicodeString::size_type UnicodeString::size() const noexcept {
+  return this->length_;
+}
+
+} // namespace d2


### PR DESCRIPTION
Addresses in [Diablo-II-Address-Table#9](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/9)

Also adds the currently incomplete UnicodeString class.