### PR TITLE
Fix C Interface UnicodeChar Destroy

### DIFF
--- a/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_unicode_char.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_unicode_char.cc
@@ -53,7 +53,7 @@ struct D2_UnicodeChar* D2_UnicodeChar_CreateArray(std::size_t count) {
 }
 
 void D2_UnicodeChar_Destroy(struct D2_UnicodeChar* ptr) {
-  D2_UnicodeChar_Destroy(ptr);
+  d2::DestroyUnicodeChar(reinterpret_cast<d2::UnicodeChar*>(ptr));
 }
 
 unsigned short D2_UnicodeChar_GetChar(const struct D2_UnicodeChar* ptr) {


### PR DESCRIPTION
The function for the C interface to destroy a UnicodeChar is unintentionally recursive and does not actually work. This has been changed to properly call the destroy function.