### PR TITLE
Add D2Lang_Unicode_strcat

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strcat.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strcat.h
@@ -35,10 +35,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRCAT_H_
+#define SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRCAT_H_
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
+#include "../../game_struct/d2_unicode_char.h"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+DLLEXPORT struct D2_UnicodeChar* D2_D2Lang_Unicode_strcat(
+    struct D2_UnicodeChar dest[],
+    const struct D2_UnicodeChar src[]
+);
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRCAT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
@@ -38,6 +38,7 @@
 #ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
 #define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
 
+#include "d2lang/d2lang_unicode_strcat.h"
 #include "d2lang/d2lang_unicode_strlen.h"
 
 #endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strcat.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strcat.hpp
@@ -35,10 +35,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRCAT_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRCAT_HPP_
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
+#include "../../game_struct/d2_unicode_char.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+namespace d2::d2lang {
+
+DLLEXPORT UnicodeChar* Unicode_strcat(
+    UnicodeChar dest[],
+    const UnicodeChar src[]
+);
+
+} // namespace d2::d2lang
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_STRCAT_HPP_

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
@@ -41,7 +41,7 @@
 #include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_strcat.hpp"
 
 D2_UnicodeChar* D2_D2Lang_Unicode_strcat(
-    D2_UnicodeChar* dest[],
+    D2_UnicodeChar dest[],
     const D2_UnicodeChar src[]
 ) {
   auto actual_dest = reinterpret_cast<d2::UnicodeChar*>(dest);

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
@@ -47,7 +47,7 @@ D2_UnicodeChar* D2_D2Lang_Unicode_strcat(
   auto actual_dest = reinterpret_cast<d2::UnicodeChar*>(dest);
   auto actual_src = reinterpret_cast<const d2::UnicodeChar*>(src);
 
-  auto ret_value = d2::d2lang::Unicode_strcat(actual_dest, actual_src);
+  d2::UnicodeChar* ret_value = d2::d2lang::Unicode_strcat(actual_dest, actual_src);
 
   return reinterpret_cast<D2_UnicodeChar*>(ret_value);
 }

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
@@ -35,10 +35,19 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../../include/c/game_func/d2lang/d2lang_unicode_strcat.h"
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
+#include "../../../../include/c/game_struct/d2_unicode_char.h"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_strcat.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+D2_UnicodeChar* D2_D2Lang_Unicode_strcat(
+    D2_UnicodeChar* dest[],
+    const D2_UnicodeChar src[]
+) {
+  auto actual_dest = reinterpret_cast<d2::UnicodeChar*>(dest);
+  auto actual_src = reinterpret_cast<const d2::UnicodeChar*>(src);
+
+  auto ret_value = d2::d2lang::Unicode_strcat(actual_dest, actual_src);
+
+  return reinterpret_cast<D2_UnicodeChar*>(ret_value);
+}

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
@@ -35,10 +35,50 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_strcat.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_struct/d2_unicode_char.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2lang {
+namespace {
+
+__declspec(naked) UnicodeChar* __cdecl
+D2Lang_Unicode_strcat_1_00(
+    std::intptr_t func_ptr,
+    const UnicodeChar* dest,
+    const UnicodeChar* src
+) {
+  ASM_X86(mov edx, [esp + 12])
+  ASM_X86(mov ecx, [esp + 8]);
+  ASM_X86(call dword ptr [esp + 4]);
+  ASM_X86(ret);
+}
+
+std::intptr_t D2Lang_Unicode_strlen() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+UnicodeChar* Unicode_strcat(
+    UnicodeChar dest[],
+    const UnicodeChar src[]
+) {
+  std::intptr_t ptr = D2Lang_Unicode_strlen();
+
+  return D2Lang_Unicode_strcat_1_00(ptr, dest, src);
+}
+
+} // namespace d2::d2lang

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
@@ -63,7 +63,7 @@ D2Lang_Unicode_strcat_1_00(
   ASM_X86(ret);
 }
 
-std::intptr_t D2Lang_Unicode_strlen() {
+std::intptr_t D2Lang_Unicode_strcat() {
   static std::intptr_t ptr = mapi::GetGameAddress(__func__)
       .raw_address();
 
@@ -76,7 +76,7 @@ UnicodeChar* Unicode_strcat(
     UnicodeChar dest[],
     const UnicodeChar src[]
 ) {
-  std::intptr_t ptr = D2Lang_Unicode_strlen();
+  std::intptr_t ptr = D2Lang_Unicode_strcat();
 
   return D2Lang_Unicode_strcat_1_00(ptr, dest, src);
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
@@ -51,7 +51,7 @@
 namespace d2::d2lang {
 namespace {
 
-__declspec(naked) std::intptr_t __cdecl
+__declspec(naked) int __cdecl
 D2Lang_Unicode_strlen_1_00(std::intptr_t func_ptr, const UnicodeChar* buffer) {
   ASM_X86(mov ecx, [esp + 8]);
   ASM_X86(call dword ptr [esp + 4]);


### PR DESCRIPTION
Addresses in [Diablo-II-Address-Table#10](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/10)

Also fixes an incorrect return type for low-level D2Lang_Unicode_strlen function.