### PR TITLE
Update license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,10 +26,10 @@ also extended to any combination of expansions, mods, and remasters of
 the game.
 
 If you modify this Program, or any covered work, by linking or combining
-it with any Glide wrapper (or a modified version of that library),
+it with any Graphics Device Interface (GDI), DirectDraw, Direct3D, Glide,
+OpenGL, or Rave wrapper (or modified versions of those libraries),
 containing parts not covered by a compatible license, the licensors of
-this Program grant you additional permission to convey the resulting
-work.
+this Program grant you additional permission to convey the resulting work.
 
 # JSON for Modern C++
 Copyright (c) 2013-2018 Niels Lohmann

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,10 +26,18 @@ also extended to any combination of expansions, mods, and remasters of
 the game.
 
 If you modify this Program, or any covered work, by linking or combining
-it with any Graphics Device Interface (GDI), DirectDraw, Direct3D, Glide,
-OpenGL, or Rave wrapper (or modified versions of those libraries),
+it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+Glide, OpenGL, or Rave wrapper (or modified versions of those
+libraries), containing parts not covered by a compatible license, the
+licensors of this Program grant you additional permission to convey the
+resulting work.
+
+If you modify this Program, or any covered work, by linking or combining
+it with any library (or a modified version of that library) that links
+to Diablo II (or a modified version of that game and its libraries),
 containing parts not covered by a compatible license, the licensors of
-this Program grant you additional permission to convey the resulting work.
+this Program grant you additional permission to convey the resulting
+work.
 
 # JSON for Modern C++
 Copyright (c) 2013-2018 Niels Lohmann

--- a/SlashGaming-Diablo-II-API/include/c/default_game_library.h
+++ b/SlashGaming-Diablo-II-API/include/c/default_game_library.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_address.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_address.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_address/game_decorated_name.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_address/game_decorated_name.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_address/game_offset.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_address/game_offset.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_address/game_ordinal.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_address/game_ordinal.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_bool.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_bool.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_branch_type.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_branch_type.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_constant.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_constant.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_constant/d2_difficulty_level.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_constant/d2_difficulty_level.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/bnclient_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/bnclient_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_difficulty_level.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_difficulty_level.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_ingame_mouse_position.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_ingame_mouse_position.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_automap_open.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_automap_open.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_game_menu_open.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_game_menu_open.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_help_screen_open.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_help_screen_open.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_new_skill_button_pressed.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_new_skill_button_pressed.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_new_stats_button_pressed.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client/d2client_is_new_stats_button_pressed.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2client_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2client_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2cmp_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2cmp_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2common_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2common_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2game_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2game_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gfx/d2gfx_resolution_mode.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gfx/d2gfx_resolution_mode.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gfx_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gfx_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2glide_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2glide_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2lang_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2lang_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2launch_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2launch_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2mcpclient_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2mcpclient_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2multi_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2multi_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2net_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2net_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2sound_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2sound_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2win/d2win_main_menu_mouse_position.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2win/d2win_main_menu_mouse_position.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2win_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2win_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/fog_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/fog_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_data/storm_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/storm_data.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/bnclient_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/bnclient_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2client_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2client_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2cmp_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2cmp_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2common_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2common_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2ddraw_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2ddraw_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2direct3d_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2direct3d_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2game_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2game_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2gdi_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2gdi_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2gfx_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2gfx_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2glide_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2glide_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strcat.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strcat.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strlen.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_strlen.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2launch_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2launch_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2mcpclient_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2mcpclient_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2multi_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2multi_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2net_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2net_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2sound_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2sound_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2win_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2win_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/fog_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/fog_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_func/storm_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/storm_func.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_patch.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_patch.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_patch/game_back_branch_patch.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_patch/game_back_branch_patch.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_patch/game_branch_patch.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_patch/game_branch_patch.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_patch/game_buffer_patch.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_patch/game_buffer_patch.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_patch/game_nop_patch.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_patch/game_nop_patch.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_struct.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive_handle.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive_handle.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_struct/d2_unicode_char.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct/d2_unicode_char.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/c/game_version.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_version.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/default_game_library.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/default_game_library.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_bool.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_bool.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_branch_type.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_branch_type.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_constant.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_constant.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_constant.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_constant.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_difficulty_level.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_difficulty_level.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/bnclient_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/bnclient_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_difficulty_level.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_difficulty_level.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_ingame_mouse_position.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_ingame_mouse_position.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_automap_open.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_automap_open.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_game_menu_open.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_game_menu_open.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_help_screen_open.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_help_screen_open.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_new_skill_button_pressed.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_new_skill_button_pressed.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_new_stats_button_pressed.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client/d2client_is_new_stats_button_pressed.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2client_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2cmp_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2cmp_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2common_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2common_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2game_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2game_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gfx/d2gfx_resolution_mode.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gfx/d2gfx_resolution_mode.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gfx_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gfx_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2glide_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2glide_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2lang_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2lang_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2launch_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2launch_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2mcpclient_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2mcpclient_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2multi_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2multi_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2net_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2net_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2sound_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2sound_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2win/d2win_main_menu_mouse_position.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2win/d2win_main_menu_mouse_position.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2win_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2win_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/fog_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/fog_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/storm_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/storm_data.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/bnclient_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/bnclient_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2client_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2client_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2cmp_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2cmp_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2common_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2common_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2ddraw_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2ddraw_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2direct3d_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2direct3d_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2game_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2game_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gdi_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gdi_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gfx_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2gfx_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2glide_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2glide_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strcat.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strcat.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2launch_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2launch_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2mcpclient_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2mcpclient_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2multi_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2multi_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2net_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2net_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2sound_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2sound_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/fog_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/fog_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/storm_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/storm_func.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_unicode_char.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_unicode_char.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/cxx/game_version.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_version.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/d2api_version.h
+++ b/SlashGaming-Diablo-II-API/include/d2api_version.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/dllexport_define.inc
+++ b/SlashGaming-Diablo-II-API/include/dllexport_define.inc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/dllexport_undefine.inc
+++ b/SlashGaming-Diablo-II-API/include/dllexport_undefine.inc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/sgd2mapi.h
+++ b/SlashGaming-Diablo-II-API/include/sgd2mapi.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/include/sgd2mapi.hpp
+++ b/SlashGaming-Diablo-II-API/include/sgd2mapi.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/resource/resource.rc
+++ b/SlashGaming-Diablo-II-API/resource/resource.rc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/asm_x86_macro.h
+++ b/SlashGaming-Diablo-II-API/src/asm_x86_macro.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/c_default_game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/c/c_default_game_library.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/c_game_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/c/c_game_patch.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/c_game_version.cc
+++ b/SlashGaming-Diablo-II-API/src/c/c_game_version.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_address/c_game_decorated_name.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_address/c_game_decorated_name.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_address/c_game_offset.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_address/c_game_offset.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_address/c_game_ordinal.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_address/c_game_ordinal.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_constant/c_d2_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_constant/c_d2_difficulty_level.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_difficulty_level.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_ingame_mouse_position.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_ingame_mouse_position.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_automap_open.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_automap_open.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_game_menu_open.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_game_menu_open.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_help_screen_open.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_help_screen_open.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_new_skill_button_pressed.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_new_skill_button_pressed.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_new_stats_button_pressed.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2client/c_d2client_is_new_stats_button_pressed.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2gfx/c_d2gfx_resolution_mode.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2gfx/c_d2gfx_resolution_mode.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2win/c_d2win_main_menu_mouse_position.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2win/c_d2win_main_menu_mouse_position.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_back_branch_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_back_branch_patch.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_branch_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_branch_patch.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_buffer_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_buffer_patch.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_nop_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_patch/c_game_nop_patch.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive_handle.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive_handle.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_unicode_char.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_unicode_char.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/architecture_opcode.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/architecture_opcode.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/architecture_opcode.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/architecture_opcode.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/config_parser.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/config_parser.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/config_parser.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/config_parser.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address_table.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address_table.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address_table.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address_table.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address_table_reader.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address_table_reader.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address_table_reader.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address_table_reader.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_constant_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_constant_impl.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_difficulty_level.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_difficulty_level.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_difficulty_level.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_ingame_mouse_position.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_ingame_mouse_position.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_automap_open.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_automap_open.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_game_menu_open.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_game_menu_open.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_help_screen_open.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_help_screen_open.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_new_skill_button_pressed.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_new_skill_button_pressed.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_new_stats_button_pressed.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2client/d2client_is_new_stats_button_pressed.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gfx/d2gfx_resolution_mode.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gfx/d2gfx_resolution_mode.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2win/d2win_menu_main_mouse_position.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2win/d2win_menu_main_mouse_position.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_library.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_library.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_library.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_back_branch_patch_buffer.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_back_branch_patch_buffer.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_back_branch_patch_buffer.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_back_branch_patch_buffer.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_branch_patch_buffer.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_branch_patch_buffer.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_branch_patch_buffer.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch/game_branch_patch_buffer.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_api.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_const_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_const_wrapper.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_impl.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive/d2_mpq_archive_wrapper.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_impl.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_api.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_const_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_const_wrapper.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_impl.hpp
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_traits.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_traits.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_wrapper.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_string.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_string.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.

--- a/SlashGaming-Diablo-II-API/src/wide_macro.h
+++ b/SlashGaming-Diablo-II-API/src/wide_macro.h
@@ -29,7 +29,15 @@
  *  the game.
  *
  *  If you modify this Program, or any covered work, by linking or combining
- *  it with any Glide wrapper (or a modified version of that library),
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
  *  containing parts not covered by a compatible license, the licensors of
  *  this Program grant you additional permission to convey the resulting
  *  work.


### PR DESCRIPTION
The license has been updated once again, to allow linking to GDI, DirectDraw, Direct3D, Glide, OpenGL, and Rave wrappers. Previously, only Glide wrappers were permitted.

In addition, any library that also links to Diablo II and/or its libraries becomes fair game to link to. This allows others to use this API to link to other people's code edit DLLs for compatibility purposes.