### PR TITLE
Update Address to Current

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_display_height.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_display_height.h
@@ -43,10 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_HEIGHT_H_
+#define SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_HEIGHT_H_
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2DDraw_GetDisplayHeight(void);
+DLLEXPORT void D2_D2DDraw_SetDisplayHeight(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_HEIGHT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_display_width.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_display_width.h
@@ -43,10 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_WIDTH_H_
+#define SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_WIDTH_H_
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2DDraw_GetDisplayWidth(void);
+DLLEXPORT void D2_D2DDraw_SetDisplayWidth(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_WIDTH_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d/d2direct3d_display_height.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d/d2direct3d_display_height.h
@@ -43,10 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_HEIGHT_H_
+#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_HEIGHT_H_
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2Direct3D_GetDisplayHeight(void);
+DLLEXPORT void D2_D2Direct3D_SetDisplayHeight(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_HEIGHT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d/d2direct3d_display_width.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2direct3d/d2direct3d_display_width.h
@@ -43,10 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_WIDTH_H_
+#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_WIDTH_H_
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2Direct3D_GetDisplayWidth(void);
+DLLEXPORT void D2_D2Direct3D_SetDisplayWidth(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_WIDTH_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_bit_block_height.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_bit_block_height.h
@@ -43,10 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_HEIGHT_H_
+#define SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_HEIGHT_H_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2GDI_GetBitBlockHeight(void);
+DLLEXPORT void D2_D2GDI_SetBitBlockHeight(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_HEIGHT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_bit_block_width.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_bit_block_width.h
@@ -43,10 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_WIDTH_H_
+#define SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_WIDTH_H_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2GDI_GetBitBlockWidth(void);
+DLLEXPORT void D2_D2GDI_SetBitBlockWidth(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_WIDTH_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_cel_display_left.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_cel_display_left.h
@@ -43,12 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_LEFT_H_
+#define SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_LEFT_H_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2GDI_GetCelDisplayLeft(void);
+DLLEXPORT void D2_D2GDI_SetCelDisplayLeft(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_LEFT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_cel_display_right.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2gdi/d2gdi_cel_display_right.h
@@ -43,12 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_RIGHT_H_
+#define SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_RIGHT_H_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2GDI_GetCelDisplayRight(void);
+DLLEXPORT void D2_D2GDI_SetCelDisplayRight(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_RIGHT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_get_string_by_index.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_get_string_by_index.h
@@ -43,13 +43,24 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_GET_STRING_BY_INDEX_H_
+#define SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_GET_STRING_BY_INDEX_H_
 
-#include "d2lang/d2lang_get_string_by_index.hpp"
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../game_struct/d2_unicode_char.h"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT const struct D2_UnicodeChar* D2_D2Lang_GetStringByIndex(
+    unsigned int id
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_GET_STRING_BY_INDEX_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_tolower.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_tolower.h
@@ -43,11 +43,25 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOLOWER_H_
+#define SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOLOWER_H_
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
+#include "../../game_struct/d2_unicode_char.h"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT struct D2_UnicodeChar* D2_D2Lang_Unicode_tolower(
+    const struct D2_UnicodeChar* src,
+    struct D2_UnicodeChar* dest
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOLOWER_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_toupper.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang/d2lang_unicode_toupper.h
@@ -43,12 +43,25 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOUPPER_H_
+#define SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOUPPER_H_
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../game_struct/d2_unicode_char.h"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT struct D2_UnicodeChar* D2_D2Lang_Unicode_toupper(
+    const struct D2_UnicodeChar* src,
+    struct D2_UnicodeChar* dest
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOUPPER_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
@@ -46,6 +46,7 @@
 #ifndef SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
 #define SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_
 
+#include "d2lang/d2lang_get_string_by_index.h"
 #include "d2lang/d2lang_unicode_strcat.h"
 #include "d2lang/d2lang_unicode_strlen.h"
 #include "d2lang/d2lang_unicode_tolower.h"

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
@@ -49,5 +49,6 @@
 #include "d2lang/d2lang_unicode_strcat.h"
 #include "d2lang/d2lang_unicode_strlen.h"
 #include "d2lang/d2lang_unicode_tolower.h"
+#include "d2lang/d2lang_unicode_toupper.h"
 
 #endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2lang_func.h
@@ -48,5 +48,6 @@
 
 #include "d2lang/d2lang_unicode_strcat.h"
 #include "d2lang/d2lang_unicode_strlen.h"
+#include "d2lang/d2lang_unicode_tolower.h"
 
 #endif // SGD2MAPI_C_GAME_FUNC_D2LANG_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2win/d2win_load_mpq.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2win/d2win_load_mpq.h
@@ -43,9 +43,29 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2WIN_D2WIN_LOAD_MPQ_H_
+#define SGD2MAPI_C_GAME_FUNC_D2WIN_D2WIN_LOAD_MPQ_H_
 
-#include "d2win/d2win_load_mpq.hpp"
+#include <stdbool.h>
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
+#include "../../game_struct/d2_mpq_archive_handle.h"
+
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT struct D2_MPQArchiveHandle* D2_D2Win_LoadMPQ(
+    const char* mpq_file_name,
+    bool is_set_err_on_drive_query_fail,
+    void* (*on_fail_callback)(void),
+    int priority
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_D2WIN_D2WIN_LOAD_MPQ_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2win/d2win_unload_mpq.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2win/d2win_unload_mpq.h
@@ -43,10 +43,24 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_D2WIN_D2WIN_UNLOAD_MPQ_H_
+#define SGD2MAPI_C_GAME_FUNC_D2WIN_D2WIN_UNLOAD_MPQ_H_
 
-#include "d2win/d2win_load_mpq.h"
-#include "d2win/d2win_unload_mpq.h"
+#include "../../game_struct/d2_mpq_archive_handle.h"
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT void D2_D2Win_UnloadMPQ(
+    struct D2_MPQArchiveHandle* mpq_archive_handle
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_D2WIN_D2WIN_UNLOAD_MPQ_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/d2win_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/d2win_func.h
@@ -46,4 +46,6 @@
 #ifndef SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
 #define SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
 
+#include "d2win/d2win_load_mpq.h"
+
 #endif // SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/fog/fog_alloc_client_memory.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/fog/fog_alloc_client_memory.h
@@ -43,9 +43,25 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_FOG_FOG_ALLOC_CLIENT_MEMORY_H_
+#define SGD2MAPI_C_GAME_FUNC_FOG_FOG_ALLOC_CLIENT_MEMORY_H_
 
-#include "fog/fog_alloc_client_memory.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT void* D2_Fog_AllocClientMemory(
+    int size,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_FOG_FOG_ALLOC_CLIENT_MEMORY_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/fog/fog_free_client_memory.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/fog/fog_free_client_memory.h
@@ -43,10 +43,27 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+#ifndef SGD2MAPI_C_GAME_FUNC_FOG_FOG_FREE_CLIENT_MEMORY_H_
+#define SGD2MAPI_C_GAME_FUNC_FOG_FOG_FREE_CLIENT_MEMORY_H_
 
-#include "fog/fog_alloc_client_memory.hpp"
-#include "fog/fog_free_client_memory.hpp"
+#include <stdbool.h>
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT bool D2_Fog_FreeClientMemory(
+    void* ptr,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_FOG_FOG_FREE_CLIENT_MEMORY_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/fog_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/fog_func.h
@@ -47,5 +47,6 @@
 #define SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
 
 #include "fog/fog_alloc_client_memory.h"
+#include "fog/fog_free_client_memory.h"
 
 #endif // SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/storm/storm_s_file_close_archive.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/storm/storm_s_file_close_archive.h
@@ -43,9 +43,26 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+#ifndef SGD2MAPI_C_GAME_FUNC_STORM_STORM_S_FILE_CLOSE_ARCHIVE_H_
+#define SGD2MAPI_C_GAME_FUNC_STORM_STORM_S_FILE_CLOSE_ARCHIVE_H_
 
-#include "storm/storm_s_file_close_archive.h"
+#include <stdbool.h>
 
-#endif // SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+#include "../../game_struct/d2_mpq_archive.h"
+
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT bool D2_Storm_SFileCloseArchive(
+    struct D2_MPQArchive* mpq_archive
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_STORM_STORM_S_FILE_CLOSE_ARCHIVE_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/storm/storm_s_file_open_archive.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/storm/storm_s_file_open_archive.h
@@ -43,10 +43,29 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+#ifndef SGD2MAPI_C_GAME_FUNC_STORM_STORM_S_FILE_OPEN_ARCHIVE_H_
+#define SGD2MAPI_C_GAME_FUNC_STORM_STORM_S_FILE_OPEN_ARCHIVE_H_
 
-#include "storm/storm_s_file_close_archive.hpp"
-#include "storm/storm_s_file_open_archive.hpp"
+#include <stdbool.h>
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+#include "../../game_struct/d2_mpq_archive.h"
+
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT bool D2_Storm_SFileOpenArchive(
+    const char* mpq_archive_path,
+    int priority,
+    unsigned int flags,
+    struct D2_MPQArchive** mpq_archive_ptr_out
+);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_FUNC_STORM_STORM_S_FILE_OPEN_ARCHIVE_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_func/storm_func.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_func/storm_func.h
@@ -47,5 +47,6 @@
 #define SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
 
 #include "storm/storm_s_file_close_archive.h"
+#include "storm/storm_s_file_open_archive.h"
 
 #endif // SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive_handle.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive_handle.h
@@ -60,8 +60,16 @@ DLLEXPORT struct D2_MPQArchive* D2_MPQArchiveHandle_GetMPQArchive(
     struct D2_MPQArchiveHandle* ptr
 );
 
+DLLEXPORT const struct D2_MPQArchive* D2_MPQArchiveHandle_GetConstMPQArchive(
+    const struct D2_MPQArchiveHandle* ptr
+);
+
 DLLEXPORT char* D2_MPQArchiveHandle_GetMPQArchivePath(
     struct D2_MPQArchiveHandle* ptr
+);
+
+DLLEXPORT const char* D2_MPQArchiveHandle_GetConstMPQArchivePath(
+    const struct D2_MPQArchiveHandle* ptr
 );
 
 #ifdef __cplusplus

--- a/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive_handle.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct/d2_mpq_archive_handle.h
@@ -52,13 +52,21 @@
 
 struct D2_MPQArchiveHandle;
 
-DLLEXPORT const struct D2_MPQArchive* D2_MPQArchiveHandle_GetMPQArchive(
-    const struct D2_MPQArchiveHandle* ptr
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT struct D2_MPQArchive* D2_MPQArchiveHandle_GetMPQArchive(
+    struct D2_MPQArchiveHandle* ptr
 );
 
-DLLEXPORT const char* D2_MPQArchiveHandle_GetMPQArchivePath(
-    const struct D2_MPQArchiveHandle* ptr
+DLLEXPORT char* D2_MPQArchiveHandle_GetMPQArchivePath(
+    struct D2_MPQArchiveHandle* ptr
 );
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #include "../../dllexport_undefine.inc"
 #endif // SGD2MAPI_C_GAME_STRUCT_D2_MPQ_ARCHIVE_HANDLE_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_struct/d2_unicode_char.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_struct/d2_unicode_char.h
@@ -52,6 +52,10 @@
 
 struct D2_UnicodeChar;
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 DLLEXPORT struct D2_UnicodeChar* D2_UnicodeChar_CreateDefault(void);
 DLLEXPORT struct D2_UnicodeChar* D2_UnicodeChar_CreateWithChar(unsigned short ch);
 DLLEXPORT struct D2_UnicodeChar* D2_UnicodeChar_CreateArray(size_t count);
@@ -66,6 +70,10 @@ DLLEXPORT void D2_UnicodeChar_SetChar(
     struct D2_UnicodeChar* ptr,
     unsigned short ch
 );
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #include "../../dllexport_undefine.inc"
 #endif // SGD2MAPI_C_GAME_STRUCT_D2_UNICODE_CHAR_H_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_display_height.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_display_height.hpp
@@ -43,10 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_HEIGHT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_HEIGHT_HPP_
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+namespace d2::d2ddraw {
+
+DLLEXPORT int GetDisplayHeight();
+DLLEXPORT void SetDisplayHeight(int value);
+
+} // namespace d2::d2ddraw
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_HEIGHT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_display_width.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_display_width.hpp
@@ -43,10 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_WIDTH_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_WIDTH_HPP_
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+namespace d2::d2ddraw {
+
+DLLEXPORT int GetDisplayWidth();
+DLLEXPORT void SetDisplayWidth(int value);
+
+} // namespace d2::d2ddraw
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_DISPLAY_WIDTH_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
@@ -46,4 +46,7 @@
 #ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
 #define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
 
+#include "d2ddraw/d2ddraw_display_height.hpp"
+#include "d2ddraw/d2ddraw_display_width.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d/d2direct3d_display_height.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d/d2direct3d_display_height.hpp
@@ -43,10 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_HEIGHT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_HEIGHT_HPP_
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+namespace d2::d2direct3d {
+
+DLLEXPORT int GetDisplayHeight();
+DLLEXPORT void SetDisplayHeight(int value);
+
+} // namespace d2::d2direct3d
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_HEIGHT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d/d2direct3d_display_width.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d/d2direct3d_display_width.hpp
@@ -43,10 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_WIDTH_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_WIDTH_HPP_
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+namespace d2::d2direct3d {
+
+DLLEXPORT int GetDisplayWidth();
+DLLEXPORT void SetDisplayWidth(int value);
+
+} // namespace d2::d2direct3d
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_D2DIRECT3D_DISPLAY_WIDTH_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2direct3d_data.hpp
@@ -46,4 +46,7 @@
 #ifndef SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_DATA_HPP_
 #define SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_DATA_HPP_
 
+#include "d2direct3d/d2direct3d_display_height.hpp"
+#include "d2direct3d/d2direct3d_display_width.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_DATA_D2DIRECT3D_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_bit_block_height.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_bit_block_height.hpp
@@ -43,10 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_HEIGHT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_HEIGHT_HPP_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+namespace d2::d2gdi {
+
+DLLEXPORT int GetBitBlockHeight();
+DLLEXPORT void SetBitBlockHeight(int value);
+
+} // namespace d2::d2gdi
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_HEIGHT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_bit_block_width.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_bit_block_width.hpp
@@ -43,10 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_WIDTH_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_WIDTH_HPP_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+namespace d2::d2gdi {
+
+DLLEXPORT int GetBitBlockWidth();
+DLLEXPORT void SetBitBlockWidth(int value);
+
+} // namespace d2::d2gdi
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_BIT_BLOCK_WIDTH_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_cel_display_left.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_cel_display_left.hpp
@@ -43,12 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_LEFT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_LEFT_HPP_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+namespace d2::d2gdi {
+
+DLLEXPORT int GetCelDisplayLeft();
+DLLEXPORT void SetCelDisplayLeft(int value);
+
+} // namespace d2::d2gdi
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_LEFT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_cel_display_right.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi/d2gdi_cel_display_right.hpp
@@ -43,12 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_RIGHT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_RIGHT_HPP_
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+namespace d2::d2gdi {
+
+DLLEXPORT int GetCelDisplayRight();
+DLLEXPORT void SetCelDisplayRight(int value);
+
+} // namespace d2::d2gdi
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2GDI_D2GDI_CEL_DISPLAY_RIGHT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
@@ -46,4 +46,7 @@
 #ifndef SGD2MAPI_CXX_GAME_DATA_D2GDI_DATA_HPP_
 #define SGD2MAPI_CXX_GAME_DATA_D2GDI_DATA_HPP_
 
+#include "d2gdi/d2gdi_bit_block_height.hpp"
+#include "d2gdi/d2gdi_bit_block_width.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_DATA_D2GDI_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2gdi_data.hpp
@@ -48,5 +48,7 @@
 
 #include "d2gdi/d2gdi_bit_block_height.hpp"
 #include "d2gdi/d2gdi_bit_block_width.hpp"
+#include "d2gdi/d2gdi_cel_display_left.hpp"
+#include "d2gdi/d2gdi_cel_display_right.hpp"
 
 #endif // SGD2MAPI_CXX_GAME_DATA_D2GDI_DATA_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_get_string_by_index.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_get_string_by_index.hpp
@@ -43,13 +43,20 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_GET_STRING_BY_INDEX_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_GET_STRING_BY_INDEX_HPP_
 
-#include "d2lang/d2lang_get_string_by_index.hpp"
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../game_struct/d2_unicode_char.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+namespace d2::d2lang {
+
+DLLEXPORT const UnicodeChar* GetStringByIndex(
+    unsigned int id
+);
+
+} // namespace d2::d2lang
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_GET_STRING_BY_INDEX_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_tolower.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_tolower.hpp
@@ -43,11 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOLOWER_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOLOWER_HPP_
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
+#include "../../game_struct/d2_unicode_char.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+namespace d2::d2lang {
+
+DLLEXPORT UnicodeChar* Unicode_tolower(
+    const UnicodeChar* src,
+    UnicodeChar* dest
+);
+
+} // namespace d2::d2lang
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOLOWER_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_toupper.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2lang/d2lang_unicode_toupper.hpp
@@ -43,12 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOUPPER_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOUPPER_HPP_
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../game_struct/d2_unicode_char.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+namespace d2::d2lang {
+
+DLLEXPORT UnicodeChar* Unicode_toupper(
+    const UnicodeChar* src,
+    UnicodeChar* dest
+);
+
+} // namespace d2::d2lang
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_D2LANG_UNICODE_TOUPPER_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win/d2win_load_mpq.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win/d2win_load_mpq.hpp
@@ -43,9 +43,23 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2WIN_D2WIN_LOAD_MPQ_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2WIN_D2WIN_LOAD_MPQ_HPP_
 
-#include "d2win/d2win_load_mpq.hpp"
+#include "../../game_struct/d2_mpq_archive_handle.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+namespace d2::d2win {
+
+DLLEXPORT MPQArchiveHandle* LoadMPQ(
+    const char* mpq_file_name,
+    bool is_set_err_on_drive_query_fail,
+    void* (*on_fail_callback)(void),
+    int priority
+);
+
+} // namespace d2::d2win
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2WIN_D2WIN_LOAD_MPQ_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win/d2win_unload_mpq.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win/d2win_unload_mpq.hpp
@@ -43,10 +43,20 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_D2WIN_D2WIN_UNLOAD_MPQ_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_D2WIN_D2WIN_UNLOAD_MPQ_HPP_
 
-#include "d2win/d2win_load_mpq.h"
-#include "d2win/d2win_unload_mpq.h"
+#include "../../game_struct/d2_mpq_archive_handle.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
+#include "../../../dllexport_define.inc"
+
+namespace d2::d2win {
+
+DLLEXPORT void UnloadMPQ(
+    MPQArchiveHandle* mpq_archive_handle
+);
+
+} // namespace d2::d2win
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_D2WIN_D2WIN_UNLOAD_MPQ_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/d2win_func.hpp
@@ -47,5 +47,6 @@
 #define SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
 
 #include "d2win/d2win_load_mpq.hpp"
+#include "d2win/d2win_unload_mpq.hpp"
 
 #endif // SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/fog/fog_alloc_client_memory.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/fog/fog_alloc_client_memory.hpp
@@ -43,9 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FOG_ALLOC_CLIENT_MEMORY_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_FOG_FOG_ALLOC_CLIENT_MEMORY_HPP_
 
-#include "fog/fog_alloc_client_memory.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+namespace d2::fog {
+
+DLLEXPORT void* AllocClientMemory(
+    int size,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+);
+
+} // namespace d2::fog
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FOG_ALLOC_CLIENT_MEMORY_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/fog/fog_free_client_memory.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/fog/fog_free_client_memory.hpp
@@ -43,10 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FOG_FREE_CLIENT_MEMORY_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_FOG_FOG_FREE_CLIENT_MEMORY_HPP_
 
-#include "fog/fog_alloc_client_memory.hpp"
-#include "fog/fog_free_client_memory.hpp"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+namespace d2::fog {
+
+DLLEXPORT bool FreeClientMemory(
+    void* ptr,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+);
+
+} // namespace d2::fog
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FOG_FREE_CLIENT_MEMORY_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/fog_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/fog_func.hpp
@@ -46,4 +46,6 @@
 #ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
 #define SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
 
+#include "fog/fog_alloc_client_memory.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/storm/storm_s_file_close_archive.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/storm/storm_s_file_close_archive.hpp
@@ -43,9 +43,20 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_STORM_S_FILE_CLOSE_ARCHIVE_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_STORM_STORM_S_FILE_CLOSE_ARCHIVE_HPP_
 
-#include "storm/storm_s_file_close_archive.h"
+#include "../../game_struct/d2_mpq_archive.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+#include "../../../dllexport_define.inc"
+
+namespace d2::storm {
+
+DLLEXPORT bool SFileCloseArchive(
+    MPQArchive* mpq_archive
+);
+
+} // namespace d2::storm
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_STORM_STORM_S_FILE_CLOSE_ARCHIVE_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/storm/storm_s_file_open_archive.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/storm/storm_s_file_open_archive.hpp
@@ -43,10 +43,23 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+#ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_STORM_S_FILE_OPEN_ARCHIVE_HPP_
+#define SGD2MAPI_CXX_GAME_FUNC_STORM_STORM_S_FILE_OPEN_ARCHIVE_HPP_
 
-#include "storm/storm_s_file_close_archive.hpp"
-#include "storm/storm_s_file_open_archive.hpp"
+#include "../../game_struct/d2_mpq_archive.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+#include "../../../dllexport_define.inc"
+
+namespace d2::storm {
+
+DLLEXPORT bool SFileOpenArchive(
+    const char* mpq_archive_path,
+    int priority,
+    unsigned int flags,
+    MPQArchive** mpq_archive_ptr_out
+);
+
+} // namespace d2::storm
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_FUNC_STORM_STORM_S_FILE_OPEN_ARCHIVE_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_func/storm_func.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_func/storm_func.hpp
@@ -46,4 +46,6 @@
 #ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
 #define SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
 
+#include "storm/storm_s_file_close_archive.hpp"
+
 #endif // SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
@@ -78,8 +78,8 @@ class DLLEXPORT MPQArchiveHandle_ConstWrapper {
 
   const MPQArchiveHandle* Get() const noexcept;
 
-  const MPQArchive* GetMPQArchive() const noexcept;
-  const char* GetMPQArchivePath() const noexcept;
+  const MPQArchive* mpq_archive() const noexcept;
+  const char* mpq_archive_path() const noexcept;
 
  private:
   const MPQArchiveHandle* ptr_;
@@ -103,8 +103,8 @@ class DLLEXPORT MPQArchiveHandle_Wrapper :
 
   MPQArchiveHandle* Get() noexcept;
 
-  MPQArchive* GetMPQArchive() noexcept;
-  char* GetMPQArchivePath() noexcept;
+  MPQArchive* mpq_archive() noexcept;
+  char* mpq_archive_path() noexcept;
 
  private:
   MPQArchiveHandle* ptr_;

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
@@ -114,13 +114,13 @@ class DLLEXPORT MPQArchiveHandle_API : public MPQArchiveHandle_Wrapper {
  public:
   MPQArchiveHandle_API(
       const std::filesystem::path& mpq_archive_path,
-      bool is_set_error_on_fail,
+      bool is_set_error_on_drive_query_fail,
       int priority
   );
 
   MPQArchiveHandle_API(
       const std::filesystem::path& mpq_archive_path,
-      bool is_set_error_on_fail,
+      bool is_set_error_on_drive_query_fail,
       void* (*on_fail_callback)(),
       int priority
   );

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
@@ -78,10 +78,10 @@ class DLLEXPORT MPQArchiveHandle_ConstWrapper {
 
   operator const MPQArchiveHandle*() const noexcept;
 
-  virtual const MPQArchiveHandle* Get() const noexcept;
+  const MPQArchiveHandle* Get() const noexcept;
 
-  virtual const MPQArchive* GetMPQArchive() const noexcept;
-  virtual const char* GetMPQArchivePath() const noexcept;
+  const MPQArchive* GetMPQArchive() const noexcept;
+  const char* GetMPQArchivePath() const noexcept;
 
  private:
   const MPQArchiveHandle* ptr_;
@@ -103,9 +103,12 @@ class DLLEXPORT MPQArchiveHandle_Wrapper :
       MPQArchiveHandle_Wrapper&& other
   ) noexcept;
 
-  operator MPQArchiveHandle*() const noexcept;
+  operator MPQArchiveHandle*() noexcept;
 
-  MPQArchiveHandle* Get() const noexcept override;
+  MPQArchiveHandle* Get() noexcept;
+
+  MPQArchive* GetMPQArchive() noexcept;
+  char* GetMPQArchivePath() noexcept;
 
  private:
   MPQArchiveHandle* ptr_;

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle.hpp
@@ -76,8 +76,6 @@ class DLLEXPORT MPQArchiveHandle_ConstWrapper {
       MPQArchiveHandle_ConstWrapper&& other
   ) noexcept;
 
-  operator const MPQArchiveHandle*() const noexcept;
-
   const MPQArchiveHandle* Get() const noexcept;
 
   const MPQArchive* GetMPQArchive() const noexcept;
@@ -102,8 +100,6 @@ class DLLEXPORT MPQArchiveHandle_Wrapper :
   MPQArchiveHandle_Wrapper& operator=(
       MPQArchiveHandle_Wrapper&& other
   ) noexcept;
-
-  operator MPQArchiveHandle*() noexcept;
 
   MPQArchiveHandle* Get() noexcept;
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_unicode_char.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_unicode_char.hpp
@@ -67,11 +67,9 @@ class DLLEXPORT UnicodeChar_ConstWrapper {
   UnicodeChar_ConstWrapper& operator=(const UnicodeChar_ConstWrapper& other);
   UnicodeChar_ConstWrapper& operator=(UnicodeChar_ConstWrapper&& other) noexcept;
 
-  operator const UnicodeChar*() const noexcept;
-
   operator unsigned short() const noexcept;
 
-  virtual const UnicodeChar* Get() const noexcept;
+  const UnicodeChar* Get() const noexcept;
 
   unsigned short GetChar() const noexcept;
 
@@ -92,9 +90,7 @@ class DLLEXPORT UnicodeChar_Wrapper : public UnicodeChar_ConstWrapper {
   UnicodeChar_Wrapper& operator=(const UnicodeChar_Wrapper& other);
   UnicodeChar_Wrapper& operator=(UnicodeChar_Wrapper&& other) noexcept;
 
-  operator UnicodeChar*() const noexcept;
-
-  UnicodeChar* Get() const noexcept override;
+  UnicodeChar* Get() noexcept;
 
   void SetChar(unsigned short ch) noexcept;
 

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_display_height.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_display_height.cc
@@ -43,10 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include "../../../../include/c/game_data/d2ddraw/d2ddraw_display_height.h"
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_display_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+int D2_D2DDraw_GetDisplayHeight() {
+  return d2::d2ddraw::GetDisplayHeight();
+}
+
+void D2_D2DDraw_SetDisplayHeight(int value) {
+  d2::d2ddraw::SetDisplayHeight(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_display_width.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_display_width.cc
@@ -43,10 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include "../../../../include/c/game_data/d2ddraw/d2ddraw_display_width.h"
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_display_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+int D2_D2DDraw_GetDisplayWidth() {
+  return d2::d2ddraw::GetDisplayWidth();
+}
+
+void D2_D2DDraw_SetDisplayWidth(int value) {
+  d2::d2ddraw::SetDisplayWidth(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2direct3d/c_d2direct3d_display_height.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2direct3d/c_d2direct3d_display_height.cc
@@ -43,10 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#include "../../../../include/c/game_data/d2direct3d/d2direct3d_display_height.h"
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../../include/cxx/game_data/d2direct3d/d2direct3d_display_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+int D2_D2Direct3D_GetDisplayHeight() {
+  return d2::d2direct3d::GetDisplayHeight();
+}
+
+void D2_D2Direct3D_SetDisplayHeight(int value) {
+  d2::d2direct3d::SetDisplayHeight(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2direct3d/c_d2direct3d_display_width.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2direct3d/c_d2direct3d_display_width.cc
@@ -43,10 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#include "../../../../include/c/game_data/d2direct3d/d2direct3d_display_width.h"
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../../include/cxx/game_data/d2direct3d/d2direct3d_display_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+int D2_D2Direct3D_GetDisplayWidth() {
+  return d2::d2direct3d::GetDisplayWidth();
+}
+
+void D2_D2Direct3D_SetDisplayWidth(int value) {
+  d2::d2direct3d::SetDisplayWidth(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_bit_block_height.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_bit_block_height.cc
@@ -43,10 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include "../../../../include/c/game_data/d2gdi/d2gdi_bit_block_height.h"
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_bit_block_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+int D2_D2GDI_GetBitBlockHeight() {
+  return d2::d2gdi::GetBitBlockHeight();
+}
+
+void D2_D2GDI_SetBitBlockHeight(int value) {
+  d2::d2gdi::SetBitBlockHeight(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_bit_block_width.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_bit_block_width.cc
@@ -43,10 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include "../../../../include/c/game_data/d2gdi/d2gdi_bit_block_width.h"
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_bit_block_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+int D2_D2GDI_GetBitBlockWidth() {
+  return d2::d2gdi::GetBitBlockWidth();
+}
+
+void D2_D2GDI_SetBitBlockWidth(int value) {
+  d2::d2gdi::SetBitBlockWidth(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_cel_display_left.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_cel_display_left.cc
@@ -43,12 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include "../../../../include/c/game_data/d2gdi/d2gdi_cel_display_left.h"
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_cel_display_left.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+int D2_D2GDI_GetCelDisplayLeft() {
+  return d2::d2gdi::GetCelDisplayLeft();
+}
+
+void D2_D2GDI_SetCelDisplayLeft(int value) {
+  d2::d2gdi::SetCelDisplayLeft(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_cel_display_right.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2gdi/c_d2gdi_cel_display_right.cc
@@ -43,12 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include "../../../../include/c/game_data/d2gdi/d2gdi_cel_display_right.h"
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_cel_display_right.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+int D2_D2GDI_GetCelDisplayRight() {
+  return d2::d2gdi::GetCelDisplayRight();
+}
+
+void D2_D2GDI_SetCelDisplayRight(int value) {
+  d2::d2gdi::SetCelDisplayRight(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_get_string_by_index.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_get_string_by_index.cc
@@ -43,13 +43,15 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../../include/c/game_func/d2lang/d2lang_get_string_by_index.h"
 
-#include "d2lang/d2lang_get_string_by_index.hpp"
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../../../include/c/game_struct/d2_unicode_char.h"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_get_string_by_index.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+const D2_UnicodeChar* D2_D2Lang_GetStringByIndex(
+    unsigned int id
+) {
+  const d2::UnicodeChar* actual_result = d2::d2lang::GetStringByIndex(id);
+
+  return reinterpret_cast<const D2_UnicodeChar*>(actual_result);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strcat.cc
@@ -55,7 +55,10 @@ D2_UnicodeChar* D2_D2Lang_Unicode_strcat(
   auto actual_dest = reinterpret_cast<d2::UnicodeChar*>(dest);
   auto actual_src = reinterpret_cast<const d2::UnicodeChar*>(src);
 
-  d2::UnicodeChar* ret_value = d2::d2lang::Unicode_strcat(actual_dest, actual_src);
+  d2::UnicodeChar* actual_result = d2::d2lang::Unicode_strcat(
+      actual_dest,
+      actual_src
+  );
 
-  return reinterpret_cast<D2_UnicodeChar*>(ret_value);
+  return reinterpret_cast<D2_UnicodeChar*>(actual_result);
 }

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
@@ -48,7 +48,7 @@
 #include "../../../../include/c/game_struct/d2_unicode_char.h"
 #include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp"
 
-int D2_D2Lang_Unicode_strlen(const struct D2_UnicodeChar* buffer) {
+int D2_D2Lang_Unicode_strlen(const D2_UnicodeChar* buffer) {
   auto actual_ptr = reinterpret_cast<const d2::UnicodeChar*>(buffer);
 
   return d2::d2lang::Unicode_strlen(actual_ptr);

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_strlen.cc
@@ -49,7 +49,7 @@
 #include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_strlen.hpp"
 
 int D2_D2Lang_Unicode_strlen(const D2_UnicodeChar* buffer) {
-  auto actual_ptr = reinterpret_cast<const d2::UnicodeChar*>(buffer);
+  auto actual_buffer = reinterpret_cast<const d2::UnicodeChar*>(buffer);
 
-  return d2::d2lang::Unicode_strlen(actual_ptr);
+  return d2::d2lang::Unicode_strlen(actual_buffer);
 }

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_tolower.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_tolower.cc
@@ -43,11 +43,22 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../../include/c/game_func/d2lang/d2lang_unicode_tolower.h"
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
+#include "../../../../include/c/game_struct/d2_unicode_char.h"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_tolower.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+D2_UnicodeChar* D2_D2Lang_Unicode_tolower(
+    const D2_UnicodeChar* src,
+    D2_UnicodeChar* dest
+) {
+  auto actual_src = reinterpret_cast<const d2::UnicodeChar*>(src);
+  auto actual_dest = reinterpret_cast<d2::UnicodeChar*>(dest);
+
+  d2::UnicodeChar* actual_result = d2::d2lang::Unicode_tolower(
+      actual_src,
+      actual_dest
+  );
+
+  return reinterpret_cast<D2_UnicodeChar*>(actual_result);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_toupper.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2lang/c_d2lang_unicode_toupper.cc
@@ -43,12 +43,22 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include "../../../../include/c/game_func/d2lang/d2lang_unicode_toupper.h"
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../../../include/c/game_struct/d2_unicode_char.h"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_toupper.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+D2_UnicodeChar* D2_D2Lang_Unicode_toupper(
+    const D2_UnicodeChar* src,
+    D2_UnicodeChar* dest
+) {
+  auto actual_src = reinterpret_cast<const d2::UnicodeChar*>(src);
+  auto actual_dest = reinterpret_cast<d2::UnicodeChar*>(dest);
+
+  d2::UnicodeChar* actual_result = d2::d2lang::Unicode_toupper(
+      actual_src,
+      actual_dest
+  );
+
+  return reinterpret_cast<D2_UnicodeChar*>(actual_result);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2win/c_d2win_load_mpq.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2win/c_d2win_load_mpq.cc
@@ -43,9 +43,23 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
+#include "../../../../include/c/game_func/d2win/d2win_load_mpq.h"
 
-#include "d2win/d2win_load_mpq.hpp"
+#include "../../../../include/c/game_struct/d2_mpq_archive_handle.h"
+#include "../../../../include/cxx/game_func/d2win/d2win_load_mpq.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2WIN_FUNC_HPP_
+D2_MPQArchiveHandle* D2_D2Win_LoadMPQ(
+    const char* mpq_file_name,
+    bool is_set_err_on_drive_query_fail,
+    void* (*on_fail_callback)(void),
+    int priority
+) {
+  d2::MPQArchiveHandle* actual_result = d2::d2win::LoadMPQ(
+      mpq_file_name,
+      is_set_err_on_drive_query_fail,
+      on_fail_callback,
+      priority
+  );
+
+  return reinterpret_cast<D2_MPQArchiveHandle*>(actual_result);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/d2win/c_d2win_unload_mpq.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/d2win/c_d2win_unload_mpq.cc
@@ -43,10 +43,16 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
+#include "../../../../include/c/game_func/d2win/d2win_unload_mpq.h"
 
-#include "d2win/d2win_load_mpq.h"
-#include "d2win/d2win_unload_mpq.h"
+#include "../../../../include/c/game_struct/d2_mpq_archive_handle.h"
+#include "../../../../include/cxx/game_func/d2win/d2win_unload_mpq.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_D2WIN_FUNC_H_
+void D2_D2Win_UnloadMPQ(
+    D2_MPQArchiveHandle* mpq_archive_handle
+) {
+  d2::MPQArchiveHandle* actual_mpq_archive_handle =
+      reinterpret_cast<d2::MPQArchiveHandle*>(mpq_archive_handle);
+
+  d2::d2win::UnloadMPQ(actual_mpq_archive_handle);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/fog/c_fog_alloc_client_memory.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/fog/c_fog_alloc_client_memory.cc
@@ -43,9 +43,22 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+#include "../../../../include/c/game_func/fog/fog_alloc_client_memory.h"
 
-#include "fog/fog_alloc_client_memory.h"
+#include "../../../../include/cxx/game_func/fog/fog_alloc_client_memory.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+void* D2_Fog_AllocClientMemory(
+    int size,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+) {
+  void* actual_result = d2::fog::AllocClientMemory(
+      size,
+      source_file,
+      line,
+      unused__set_to_0
+  );
+
+  return actual_result;
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/fog/c_fog_free_client_memory.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/fog/c_fog_free_client_memory.cc
@@ -43,10 +43,22 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+#include "../../../../include/c/game_func/fog/fog_free_client_memory.h"
 
-#include "fog/fog_alloc_client_memory.hpp"
-#include "fog/fog_free_client_memory.hpp"
+#include "../../../../include/cxx/game_func/fog/fog_free_client_memory.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+bool D2_Fog_FreeClientMemory(
+    void* ptr,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+) {
+  bool actual_result = d2::fog::FreeClientMemory(
+      ptr,
+      source_file,
+      line,
+      unused__set_to_0
+  );
+
+  return actual_result;
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/storm/c_storm_s_file_close_archive.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/storm/c_storm_s_file_close_archive.cc
@@ -43,9 +43,20 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+#include "../../../../include/c/game_func/storm/storm_s_file_close_archive.h"
 
-#include "storm/storm_s_file_close_archive.h"
+#include "../../../../include/cxx/game_func/storm/storm_s_file_close_archive.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+bool D2_Storm_SFileCloseArchive(
+    D2_MPQArchive* mpq_archive
+) {
+  d2::MPQArchive* actual_mpq_archive = reinterpret_cast<d2::MPQArchive*>(
+      mpq_archive
+  );
+
+  bool actual_result = d2::storm::SFileCloseArchive(
+      actual_mpq_archive
+  );
+
+  return actual_result;
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_func/storm/c_storm_s_file_open_archive.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_func/storm/c_storm_s_file_open_archive.cc
@@ -43,10 +43,25 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+#include "../../../../include/c/game_func/storm/storm_s_file_open_archive.h"
 
-#include "storm/storm_s_file_close_archive.hpp"
-#include "storm/storm_s_file_open_archive.hpp"
+#include "../../../../include/cxx/game_func/storm/storm_s_file_open_archive.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+bool D2_Storm_SFileOpenArchive(
+    const char* mpq_archive_path,
+    int priority,
+    unsigned int flags,
+    D2_MPQArchive** mpq_archive_ptr_out
+) {
+  d2::MPQArchive** actual_mpq_archive_ptr_out =
+      reinterpret_cast<d2::MPQArchive**>(mpq_archive_ptr_out);
+
+  bool actual_result = d2::storm::SFileOpenArchive(
+      mpq_archive_path,
+      priority,
+      flags,
+      actual_mpq_archive_ptr_out
+  );
+
+  return actual_result;
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive_handle.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive_handle.cc
@@ -57,12 +57,32 @@ struct D2_MPQArchive* D2_MPQArchiveHandle_GetMPQArchive(
   return reinterpret_cast<D2_MPQArchive*>(wrapper.mpq_archive());
 }
 
+const struct D2_MPQArchive* D2_MPQArchiveHandle_GetConstMPQArchive(
+    const struct D2_MPQArchiveHandle* ptr
+) {
+  const d2::MPQArchiveHandle* actual_ptr =
+      reinterpret_cast<const d2::MPQArchiveHandle*>(ptr);
+  d2::MPQArchiveHandle_ConstWrapper wrapper(actual_ptr);
+
+  return reinterpret_cast<const D2_MPQArchive*>(wrapper.mpq_archive());
+}
+
 char* D2_MPQArchiveHandle_GetMPQArchivePath(
     struct D2_MPQArchiveHandle* ptr
 ) {
   d2::MPQArchiveHandle* actual_ptr =
       reinterpret_cast<d2::MPQArchiveHandle*>(ptr);
   d2::MPQArchiveHandle_Wrapper wrapper(actual_ptr);
+
+  return wrapper.mpq_archive_path();
+}
+
+const char* D2_MPQArchiveHandle_GetConstMPQArchivePath(
+    const struct D2_MPQArchiveHandle* ptr
+) {
+  const d2::MPQArchiveHandle* actual_ptr =
+      reinterpret_cast<const d2::MPQArchiveHandle*>(ptr);
+  d2::MPQArchiveHandle_ConstWrapper wrapper(actual_ptr);
 
   return wrapper.mpq_archive_path();
 }

--- a/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive_handle.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_struct/c_d2_mpq_archive_handle.cc
@@ -47,20 +47,22 @@
 
 #include "../../../include/cxx/game_struct/d2_mpq_archive_handle.hpp"
 
-const struct D2_MPQArchive* D2_MPQArchiveHandle_GetMPQArchive(
-    const struct D2_MPQArchiveHandle* ptr
+struct D2_MPQArchive* D2_MPQArchiveHandle_GetMPQArchive(
+    struct D2_MPQArchiveHandle* ptr
 ) {
-  const auto actual_ptr = reinterpret_cast<const d2::MPQArchiveHandle*>(ptr);
-  d2::MPQArchiveHandle_ConstWrapper wrapper(actual_ptr);
+  d2::MPQArchiveHandle* actual_ptr =
+      reinterpret_cast<d2::MPQArchiveHandle*>(ptr);
+  d2::MPQArchiveHandle_Wrapper wrapper(actual_ptr);
 
-  return reinterpret_cast<const D2_MPQArchive*>(wrapper.GetMPQArchive());
+  return reinterpret_cast<D2_MPQArchive*>(wrapper.mpq_archive());
 }
 
-const char* D2_MPQArchiveHandle_GetMPQArchivePath(
-    const struct D2_MPQArchiveHandle* ptr
+char* D2_MPQArchiveHandle_GetMPQArchivePath(
+    struct D2_MPQArchiveHandle* ptr
 ) {
-  const auto actual_ptr = reinterpret_cast<const d2::MPQArchiveHandle*>(ptr);
-  d2::MPQArchiveHandle_ConstWrapper wrapper(actual_ptr);
+  d2::MPQArchiveHandle* actual_ptr =
+      reinterpret_cast<d2::MPQArchiveHandle*>(ptr);
+  d2::MPQArchiveHandle_Wrapper wrapper(actual_ptr);
 
-  return wrapper.GetMPQArchivePath();
+  return wrapper.mpq_archive_path();
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_display_height.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_display_height.cc
@@ -43,10 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_display_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2ddraw {
+namespace {
+
+std::intptr_t D2DDraw_DisplayHeight() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetDisplayHeight() {
+  std::intptr_t ptr = D2DDraw_DisplayHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetDisplayHeight(int value) {
+  std::intptr_t ptr = D2DDraw_DisplayHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2ddraw

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_display_width.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_display_width.cc
@@ -43,10 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_display_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2ddraw {
+namespace {
+
+std::intptr_t D2DDraw_DisplayWidth() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetDisplayWidth() {
+  std::intptr_t ptr = D2DDraw_DisplayWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetDisplayWidth(int value) {
+  std::intptr_t ptr = D2DDraw_DisplayWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2ddraw

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2direct3d/d2direct3d_display_height.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2direct3d/d2direct3d_display_height.cc
@@ -43,10 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../../include/cxx/game_data/d2direct3d/d2direct3d_display_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2direct3d {
+namespace {
+
+std::intptr_t D2Direct3D_DisplayHeight() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetDisplayHeight() {
+  std::intptr_t ptr = D2Direct3D_DisplayHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetDisplayHeight(int value) {
+  std::intptr_t ptr = D2Direct3D_DisplayHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2direct3d

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2direct3d/d2direct3d_display_width.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2direct3d/d2direct3d_display_width.cc
@@ -43,10 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2direct3d/d2direct3d_display_height.h"
-#include "d2direct3d/d2direct3d_display_width.h"
+#include "../../../../include/cxx/game_data/d2direct3d/d2direct3d_display_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DIRECT3D_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2direct3d {
+namespace {
+
+std::intptr_t D2Direct3D_DisplayWidth() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetDisplayWidth() {
+  std::intptr_t ptr = D2Direct3D_DisplayWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetDisplayWidth(int value) {
+  std::intptr_t ptr = D2Direct3D_DisplayWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2direct3d

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_bit_block_height.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_bit_block_height.cc
@@ -43,10 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_bit_block_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2gdi {
+namespace {
+
+std::intptr_t D2GDI_BitBlockHeight() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetBitBlockHeight() {
+  std::intptr_t ptr = D2GDI_BitBlockHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetBitBlockHeight(int value) {
+  std::intptr_t ptr = D2GDI_BitBlockHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2gdi

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_bit_block_width.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_bit_block_width.cc
@@ -43,10 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_bit_block_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2gdi {
+namespace {
+
+std::intptr_t D2GDI_BitBlockWidth() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetBitBlockWidth() {
+  std::intptr_t ptr = D2GDI_BitBlockWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetBitBlockWidth(int value) {
+  std::intptr_t ptr = D2GDI_BitBlockWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2gdi

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_cel_display_left.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_cel_display_left.cc
@@ -43,12 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_cel_display_left.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2gdi {
+namespace {
+
+std::intptr_t D2GDI_CelDisplayLeft() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetCelDisplayLeft() {
+  std::intptr_t ptr = D2GDI_CelDisplayLeft();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetCelDisplayLeft(int value) {
+  std::intptr_t ptr = D2GDI_CelDisplayLeft();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2gdi

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_cel_display_right.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2gdi/d2gdi_cel_display_right.cc
@@ -43,12 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2gdi/d2gdi_bit_block_height.h"
-#include "d2gdi/d2gdi_bit_block_width.h"
-#include "d2gdi/d2gdi_cel_display_left.h"
-#include "d2gdi/d2gdi_cel_display_right.h"
+#include "../../../../include/cxx/game_data/d2gdi/d2gdi_cel_display_right.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2GDI_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2gdi {
+namespace {
+
+std::intptr_t D2GDI_CelDisplayRight() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetCelDisplayRight() {
+  std::intptr_t ptr = D2GDI_CelDisplayRight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetCelDisplayRight(int value) {
+  std::intptr_t ptr = D2GDI_CelDisplayRight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2gdi

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_get_string_by_index.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_get_string_by_index.cc
@@ -43,13 +43,61 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2lang/d2lang_get_string_by_index.hpp"
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_get_string_by_index.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_struct/d2_unicode_char.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2lang {
+namespace {
+
+__declspec(naked) const UnicodeChar* __cdecl
+D2Lang_GetStringByIndex_1_00(
+    std::intptr_t func_ptr,
+    unsigned int id
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+std::intptr_t D2Lang_GetStringByIndex() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+const UnicodeChar* GetStringByIndex(
+    unsigned int id
+) {
+  std::intptr_t ptr = D2Lang_GetStringByIndex();
+
+  return D2Lang_GetStringByIndex_1_00(
+      ptr,
+      id
+  );
+}
+
+} // namespace d2::d2lang

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strcat.cc
@@ -65,9 +65,20 @@ D2Lang_Unicode_strcat_1_00(
     const UnicodeChar* dest,
     const UnicodeChar* src
 ) {
-  ASM_X86(mov edx, [esp + 12])
-  ASM_X86(mov ecx, [esp + 8]);
-  ASM_X86(call dword ptr [esp + 4]);
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(mov edx, dword ptr [ebp + 16]);
+  ASM_X86(mov ecx, dword ptr [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
   ASM_X86(ret);
 }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_strlen.cc
@@ -59,10 +59,21 @@
 namespace d2::d2lang {
 namespace {
 
-__declspec(naked) int __cdecl
+__declspec(naked) std::int32_t __cdecl
 D2Lang_Unicode_strlen_1_00(std::intptr_t func_ptr, const UnicodeChar* buffer) {
-  ASM_X86(mov ecx, [esp + 8]);
-  ASM_X86(call dword ptr [esp + 4]);
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(mov ecx, dword ptr [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
   ASM_X86(ret);
 }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
@@ -72,7 +72,7 @@ D2Lang_Unicode_tolower_1_00(
   ASM_X86(push edx);
 
   ASM_X86(mov ecx, [ebp + 12]);
-  ASM_X86(push dword ptr[ebp + 16]);
+  ASM_X86(push dword ptr [ebp + 16]);
   ASM_X86(call dword ptr [ebp + 8]);
 
   ASM_X86(pop edx);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
@@ -79,7 +79,6 @@ D2Lang_Unicode_tolower_1_00(
   ASM_X86(pop ecx);
 
   ASM_X86(leave);
-
   ASM_X86(ret);
 }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
@@ -71,8 +71,8 @@ D2Lang_Unicode_tolower_1_00(
   ASM_X86(push ecx);
   ASM_X86(push edx);
 
-  ASM_X86(mov ecx, [ebp + 12]);
   ASM_X86(push dword ptr [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
   ASM_X86(call dword ptr [ebp + 8]);
 
   ASM_X86(pop edx);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_tolower.cc
@@ -43,11 +43,66 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_tolower.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_struct/d2_unicode_char.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2lang {
+namespace {
+
+__declspec(naked) UnicodeChar* __cdecl
+D2Lang_Unicode_tolower_1_00(
+    std::intptr_t func_ptr,
+    const UnicodeChar* src,
+    UnicodeChar* dest
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(push dword ptr[ebp + 16]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+
+  ASM_X86(ret);
+}
+
+std::intptr_t D2Lang_Unicode_tolower() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+UnicodeChar* Unicode_tolower(
+    const UnicodeChar* src,
+    UnicodeChar* dest
+) {
+  std::intptr_t ptr = D2Lang_Unicode_tolower();
+
+  return D2Lang_Unicode_tolower_1_00(
+      ptr,
+      src,
+      dest
+  );
+}
+
+} // namespace d2::d2lang

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
@@ -71,8 +71,8 @@ D2Lang_Unicode_toupper_1_00(
   ASM_X86(push ecx);
   ASM_X86(push edx);
 
-  ASM_X86(mov ecx, [ebp + 12]);
   ASM_X86(push dword ptr [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
   ASM_X86(call dword ptr [ebp + 8]);
 
   ASM_X86(pop edx);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
@@ -43,12 +43,66 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2lang/d2lang_unicode_strcat.hpp"
-#include "d2lang/d2lang_unicode_strlen.hpp"
-#include "d2lang/d2lang_unicode_tolower.hpp"
-#include "d2lang/d2lang_unicode_toupper.hpp"
+#include "../../../../include/cxx/game_func/d2lang/d2lang_unicode_toupper.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_D2LANG_FUNC_HPP_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_struct/d2_unicode_char.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2lang {
+namespace {
+
+__declspec(naked) UnicodeChar* __cdecl
+D2Lang_Unicode_toupper_1_00(
+    std::intptr_t func_ptr,
+    const UnicodeChar* src,
+    UnicodeChar* dest
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(push dword ptr[ebp + 16]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+
+  ASM_X86(ret);
+}
+
+std::intptr_t D2Lang_Unicode_toupper() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+UnicodeChar* Unicode_toupper(
+    const UnicodeChar* src,
+    UnicodeChar* dest
+) {
+  std::intptr_t ptr = D2Lang_Unicode_toupper();
+
+  return D2Lang_Unicode_toupper_1_00(
+      ptr,
+      src,
+      dest
+  );
+}
+
+} // namespace d2::d2lang

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
@@ -79,7 +79,6 @@ D2Lang_Unicode_toupper_1_00(
   ASM_X86(pop ecx);
 
   ASM_X86(leave);
-
   ASM_X86(ret);
 }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2lang/d2lang_unicode_toupper.cc
@@ -72,7 +72,7 @@ D2Lang_Unicode_toupper_1_00(
   ASM_X86(push edx);
 
   ASM_X86(mov ecx, [ebp + 12]);
-  ASM_X86(push dword ptr[ebp + 16]);
+  ASM_X86(push dword ptr [ebp + 16]);
   ASM_X86(call dword ptr [ebp + 8]);
 
   ASM_X86(pop edx);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2win/d2win_load_mpq.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2win/d2win_load_mpq.cc
@@ -1,0 +1,287 @@
+/**
+ * SlashGaming Diablo II Modding API
+ * Copyright (C) 2018-2019  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Modding API.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+/**
+ * Latest supported version: 1.14D
+ */
+
+#include "../../../../include/cxx/game_func/d2win/d2win_load_mpq.hpp"
+
+#include <windows.h>
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_bool.hpp"
+#include "../../../../include/cxx/game_struct/d2_mpq_archive_handle.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2win {
+namespace {
+
+__declspec(naked) MPQArchiveHandle* __cdecl
+D2Win_LoadMPQ_1_00(
+    std::intptr_t func_ptr,
+    const char* dll_file_name,
+    const char* mpq_file_name,
+    const char* mpq_name,
+    // std::int32_t unused,
+    void* (*on_fail_callback)(void)
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push 0);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(mov edx, [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+__declspec(naked) MPQArchiveHandle* __cdecl
+D2Win_LoadMPQ_1_03(
+    std::intptr_t func_ptr,
+    const char* dll_file_name,
+    const char* mpq_file_name,
+    const char* mpq_name,
+    // std::int32_t unused,
+    mapi::bool32 is_set_error_on_drive_query_fail,
+    void* (*on_fail_callback)(void)
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 28]);
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push 0);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(mov edx, [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+__declspec(naked) MPQArchiveHandle* __cdecl
+D2Win_LoadMPQ_1_09D(
+    std::intptr_t func_ptr,
+    const char* dll_file_name,
+    const char* mpq_file_name,
+    const char* mpq_name,
+    // std::int32_t unused,
+    mapi::bool32 is_set_error_on_drive_query_fail,
+    void* (*on_fail_callback)(void),
+    std::int32_t priority
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 32])
+  ASM_X86(push dword ptr [ebp + 28]);
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push 0);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(mov edx, [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+__declspec(naked) MPQArchiveHandle* __cdecl
+D2Win_LoadMPQ_1_12A(
+    std::intptr_t func_ptr,
+    const char* dll_file_name,
+    const char* mpq_file_name,
+    const char* mpq_name,
+    mapi::bool32 is_set_error_on_drive_query_fail,
+    void* (*on_fail_callback)(void),
+    std::int32_t priority
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(mov eax, [ebp + 32])
+  ASM_X86(push dword ptr [ebp + 28]);
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(push dword ptr [ebp + 16]);
+  ASM_X86(push dword ptr [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+__declspec(naked) MPQArchiveHandle* __cdecl
+D2Win_LoadMPQ_1_14C(
+    std::intptr_t func_ptr,
+    const char* mpq_file_name,
+    mapi::bool32 is_set_error_on_drive_query_fail,
+    void* (*on_fail_callback)(void),
+    std::int32_t priority
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(mov edx, [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+std::intptr_t D2Win_LoadMPQ() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+MPQArchiveHandle* LoadMPQ(
+    const char* mpq_file_name,
+    bool is_set_err_on_drive_query_fail,
+    void* (*on_fail_callback)(void),
+    int priority
+) {
+  std::intptr_t ptr = D2Win_LoadMPQ();
+
+  d2::GameVersion running_game_version = d2::GetRunningGameVersionId();
+
+  if (running_game_version >= d2::GameVersion::k1_00
+      && running_game_version <= d2::GameVersion::k1_02) {
+    return D2Win_LoadMPQ_1_00(
+        ptr,
+        "SGD2MAPI",
+        mpq_file_name,
+        "SGD2MAPI",
+        on_fail_callback
+    );
+  } else if (running_game_version >= d2::GameVersion::k1_03
+      && running_game_version <= d2::GameVersion::k1_06B) {
+    return D2Win_LoadMPQ_1_03(
+        ptr,
+        "SGD2MAPI",
+        mpq_file_name,
+        "SGD2MAPI",
+        is_set_err_on_drive_query_fail,
+        on_fail_callback
+    );
+  } else if (running_game_version >= d2::GameVersion::k1_07
+      && running_game_version <= d2::GameVersion::k1_10) {
+    return D2Win_LoadMPQ_1_09D(
+        ptr,
+        "SGD2MAPI",
+        mpq_file_name,
+        "SGD2MAPI",
+        is_set_err_on_drive_query_fail,
+        on_fail_callback,
+        priority
+    );
+  } else if (running_game_version >= d2::GameVersion::k1_11
+      && running_game_version <= d2::GameVersion::k1_13D) {
+    return D2Win_LoadMPQ_1_12A(
+        ptr,
+        "SGD2MAPI",
+        mpq_file_name,
+        "SGD2MAPI",
+        is_set_err_on_drive_query_fail,
+        on_fail_callback,
+        priority
+    );
+  } else if (running_game_version >= d2::GameVersion::kClassic1_14A
+      && running_game_version <= d2::GameVersion::kLod1_14D) {
+    return D2Win_LoadMPQ_1_14C(
+        ptr,
+        mpq_file_name,
+        is_set_err_on_drive_query_fail,
+        on_fail_callback,
+        priority
+    );
+  }
+}
+
+} // namespace d2::d2win

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/d2win/d2win_unload_mpq.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/d2win/d2win_unload_mpq.cc
@@ -85,7 +85,7 @@ D2Win_UnloadMPQ_1_00(
 void D2Win_UnloadMPQ_1_11(MPQArchiveHandle* mpq_archive_handle) {
   MPQArchiveHandle_Wrapper mpq_archive_handle_wrapper(mpq_archive_handle);
 
-  MPQArchive* mpq_archive = mpq_archive_handle_wrapper.GetMPQArchive();
+  MPQArchive* mpq_archive = mpq_archive_handle_wrapper.mpq_archive();
 
   if (mpq_archive != nullptr) {
     storm::SFileCloseArchive(mpq_archive);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/fog/fog_alloc_client_memory.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/fog/fog_alloc_client_memory.cc
@@ -43,9 +43,72 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "fog/fog_alloc_client_memory.h"
+#include "../../../../include/cxx/game_func/fog/fog_alloc_client_memory.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_FOG_FUNC_H_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::fog {
+namespace {
+
+__declspec(naked) void* __cdecl
+Fog_AllocClientMemory_1_00(
+    std::intptr_t func_ptr,
+    std::int32_t size,
+    const char* source_file,
+    std::int32_t line,
+    std::int32_t unused
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(mov edx, [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+std::intptr_t Fog_AllocClientMemory() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+void* AllocClientMemory(
+    int size,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+) {
+  std::intptr_t ptr = Fog_AllocClientMemory();
+
+  return Fog_AllocClientMemory_1_00(
+      ptr,
+      size,
+      source_file,
+      line,
+      unused__set_to_0
+  );
+}
+
+} // namespace d2::fog

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/fog/fog_free_client_memory.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/fog/fog_free_client_memory.cc
@@ -43,10 +43,73 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "fog/fog_alloc_client_memory.hpp"
-#include "fog/fog_free_client_memory.hpp"
+#include "../../../../include/cxx/game_func/fog/fog_free_client_memory.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_FOG_FUNC_HPP_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_bool.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::fog {
+namespace {
+
+__declspec(naked) mapi::bool32 __cdecl
+Fog_FreeClientMemory_1_00(
+    std::intptr_t func_ptr,
+    void* ptr,
+    const char* source_file,
+    std::int32_t line,
+    std::int32_t unused
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(mov edx, [ebp + 16]);
+  ASM_X86(mov ecx, [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+std::intptr_t Fog_FreeClientMemory() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+bool FreeClientMemory(
+    void* ptr,
+    const char* source_file,
+    int line,
+    int unused__set_to_0
+) {
+  std::intptr_t func_ptr = Fog_FreeClientMemory();
+
+  return Fog_FreeClientMemory_1_00(
+      func_ptr,
+      ptr,
+      source_file,
+      line,
+      unused__set_to_0
+  );
+}
+
+} // namespace d2::fog

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/storm/storm_s_file_close_archive.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/storm/storm_s_file_close_archive.cc
@@ -43,9 +43,61 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
-#define SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "storm/storm_s_file_close_archive.h"
+#include "../../../../include/cxx/game_func/storm/storm_s_file_close_archive.hpp"
 
-#endif // SGD2MAPI_C_GAME_FUNC_STORM_FUNC_H_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_bool.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::storm {
+namespace {
+
+__declspec(naked) mapi::bool32 __cdecl
+Storm_SFileCloseArchive_1_00(
+    std::intptr_t func_ptr,
+    MPQArchive* mpq_archive
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+std::intptr_t Storm_SFileCloseArchive() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+bool SFileCloseArchive(
+    MPQArchive* mpq_archive
+) {
+  std::intptr_t ptr = Storm_SFileCloseArchive();
+
+  return Storm_SFileCloseArchive_1_00(
+      ptr,
+      mpq_archive
+  );
+}
+
+} // namespace d2::storm

--- a/SlashGaming-Diablo-II-API/src/cxx/game_func/storm/storm_s_file_open_archive.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_func/storm/storm_s_file_open_archive.cc
@@ -43,10 +43,73 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
-#define SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "storm/storm_s_file_close_archive.hpp"
-#include "storm/storm_s_file_open_archive.hpp"
+#include "../../../../include/cxx/game_func/storm/storm_s_file_open_archive.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_FUNC_STORM_FUNC_HPP_
+#include <cstdint>
+
+#include "../../../asm_x86_macro.h"
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_bool.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::storm {
+namespace {
+
+__declspec(naked) mapi::bool32 __cdecl
+Storm_SFileOpenArchive_1_00(
+    std::intptr_t func_ptr,
+    const char* mpq_file_path,
+    std::int32_t priority,
+    std::uint32_t flags,
+    MPQArchive** mpq_archive_ptr_out
+) {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push dword ptr [ebp + 24]);
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(push dword ptr [ebp + 16]);
+  ASM_X86(push dword ptr [ebp + 12]);
+  ASM_X86(call dword ptr [ebp + 8]);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+std::intptr_t Storm_SFileOpenArchive() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+bool SFileOpenArchive(
+    const char* mpq_archive_path,
+    int priority,
+    unsigned int flags,
+    MPQArchive** mpq_archive_ptr_out
+) {
+  std::intptr_t ptr = Storm_SFileOpenArchive();
+
+  return Storm_SFileOpenArchive_1_00(
+      ptr,
+      mpq_archive_path,
+      priority,
+      flags,
+      mpq_archive_ptr_out
+  );
+}
+
+} // namespace d2::storm

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
@@ -51,11 +51,11 @@ namespace d2 {
 
 MPQArchiveHandle_API::MPQArchiveHandle_API(
     const std::filesystem::path& mpq_file_path,
-    bool is_set_error_on_fail,
+    bool is_set_error_on_drive_query_fail,
     int priority
 ) : MPQArchiveHandle_API(
         mpq_file_path,
-        is_set_error_on_fail,
+        is_set_error_on_drive_query_fail,
         nullptr,
         priority
     ) {
@@ -65,7 +65,7 @@ MPQArchiveHandle_API::MPQArchiveHandle_API(
 // TODO (Mir Drualga): Implement with D2Win_LoadMPQ
 MPQArchiveHandle_API::MPQArchiveHandle_API(
     const std::filesystem::path& mpq_file_path,
-    bool is_set_error_on_fail,
+    bool is_set_error_on_drive_query_fail,
     void* (*on_fail_callback)(),
     int priority
 ) : MPQArchiveHandle_Wrapper(nullptr) {

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
@@ -47,6 +47,8 @@
 
 #include <filesystem>
 
+#include "../../../../include/cxx/game_func/d2win_func.hpp"
+
 namespace d2 {
 
 MPQArchiveHandle_API::MPQArchiveHandle_API(
@@ -59,16 +61,21 @@ MPQArchiveHandle_API::MPQArchiveHandle_API(
         nullptr,
         priority
     ) {
-  // TODO (Mir Drualga): Implement
 }
 
-// TODO (Mir Drualga): Implement with D2Win_LoadMPQ
 MPQArchiveHandle_API::MPQArchiveHandle_API(
     const std::filesystem::path& mpq_file_path,
     bool is_set_error_on_drive_query_fail,
     void* (*on_fail_callback)(),
     int priority
-) : MPQArchiveHandle_Wrapper(nullptr) {
+) : MPQArchiveHandle_Wrapper(
+        d2win::LoadMPQ(
+            mpq_file_path.u8string().data(),
+            is_set_error_on_drive_query_fail,
+            on_fail_callback,
+            priority
+        )
+    ) {
 }
 
 MPQArchiveHandle_API::MPQArchiveHandle_API(
@@ -80,7 +87,7 @@ MPQArchiveHandle_API::MPQArchiveHandle_API(
 ) noexcept = default;
 
 MPQArchiveHandle_API::~MPQArchiveHandle_API() {
-  // TODO (Mir Drualga): Implement
+  d2win::UnloadMPQ(this->Get());
 }
 
 MPQArchiveHandle_API& MPQArchiveHandle_API::operator=(

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
@@ -93,7 +93,8 @@ MPQArchiveHandle_ConstWrapper::GetMPQArchive() const noexcept {
   return reinterpret_cast<MPQArchive*>(actual_ptr->mpq_archive);
 }
 
-const char* MPQArchiveHandle_ConstWrapper::GetMPQArchivePath() const noexcept {
+const char*
+MPQArchiveHandle_ConstWrapper::GetMPQArchivePath() const noexcept {
   const auto actual_ptr = reinterpret_cast<const MPQArchiveHandle_1_00*>(
       this->Get()
   );

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
@@ -74,11 +74,6 @@ MPQArchiveHandle_ConstWrapper& MPQArchiveHandle_ConstWrapper::operator=(
     MPQArchiveHandle_ConstWrapper&& other
 ) noexcept = default;
 
-MPQArchiveHandle_ConstWrapper::operator
-const MPQArchiveHandle*() const noexcept {
-  return this->Get();
-}
-
 const MPQArchiveHandle*
 MPQArchiveHandle_ConstWrapper::Get() const noexcept {
   return this->ptr_;

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_const_wrapper.cc
@@ -80,7 +80,7 @@ MPQArchiveHandle_ConstWrapper::Get() const noexcept {
 }
 
 const MPQArchive*
-MPQArchiveHandle_ConstWrapper::GetMPQArchive() const noexcept {
+MPQArchiveHandle_ConstWrapper::mpq_archive() const noexcept {
   const auto actual_ptr = reinterpret_cast<const MPQArchiveHandle_1_00*>(
       this->Get()
   );
@@ -89,7 +89,7 @@ MPQArchiveHandle_ConstWrapper::GetMPQArchive() const noexcept {
 }
 
 const char*
-MPQArchiveHandle_ConstWrapper::GetMPQArchivePath() const noexcept {
+MPQArchiveHandle_ConstWrapper::mpq_archive_path() const noexcept {
   const auto actual_ptr = reinterpret_cast<const MPQArchiveHandle_1_00*>(
       this->Get()
   );

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
@@ -45,6 +45,8 @@
 
 #include "../../../../include/cxx/game_struct/d2_mpq_archive_handle.hpp"
 
+#include "d2_mpq_archive_handle_impl.hpp"
+
 namespace d2 {
 
 MPQArchiveHandle_Wrapper::MPQArchiveHandle_Wrapper(
@@ -72,12 +74,28 @@ MPQArchiveHandle_Wrapper& MPQArchiveHandle_Wrapper::operator=(
     MPQArchiveHandle_Wrapper&& other
 ) noexcept = default;
 
-MPQArchiveHandle_Wrapper::operator MPQArchiveHandle*() const noexcept {
+MPQArchiveHandle_Wrapper::operator MPQArchiveHandle*() noexcept {
   return this->Get();
 }
 
-MPQArchiveHandle* MPQArchiveHandle_Wrapper::Get() const noexcept {
+MPQArchiveHandle* MPQArchiveHandle_Wrapper::Get() noexcept {
   return this->ptr_;
+}
+
+MPQArchive* MPQArchiveHandle_Wrapper::GetMPQArchive() noexcept {
+  auto actual_ptr = reinterpret_cast<MPQArchiveHandle_1_00*>(
+      this->Get()
+  );
+
+  return reinterpret_cast<MPQArchive*>(actual_ptr->mpq_archive);
+}
+
+char* MPQArchiveHandle_Wrapper::GetMPQArchivePath() noexcept {
+  auto actual_ptr = reinterpret_cast<MPQArchiveHandle_1_00*>(
+      this->Get()
+  );
+
+  return actual_ptr->mpq_archive_path;
 }
 
 } // namespace d2

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
@@ -74,10 +74,6 @@ MPQArchiveHandle_Wrapper& MPQArchiveHandle_Wrapper::operator=(
     MPQArchiveHandle_Wrapper&& other
 ) noexcept = default;
 
-MPQArchiveHandle_Wrapper::operator MPQArchiveHandle*() noexcept {
-  return this->Get();
-}
-
 MPQArchiveHandle* MPQArchiveHandle_Wrapper::Get() noexcept {
   return this->ptr_;
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_wrapper.cc
@@ -78,7 +78,7 @@ MPQArchiveHandle* MPQArchiveHandle_Wrapper::Get() noexcept {
   return this->ptr_;
 }
 
-MPQArchive* MPQArchiveHandle_Wrapper::GetMPQArchive() noexcept {
+MPQArchive* MPQArchiveHandle_Wrapper::mpq_archive() noexcept {
   auto actual_ptr = reinterpret_cast<MPQArchiveHandle_1_00*>(
       this->Get()
   );
@@ -86,7 +86,7 @@ MPQArchive* MPQArchiveHandle_Wrapper::GetMPQArchive() noexcept {
   return reinterpret_cast<MPQArchive*>(actual_ptr->mpq_archive);
 }
 
-char* MPQArchiveHandle_Wrapper::GetMPQArchivePath() noexcept {
+char* MPQArchiveHandle_Wrapper::mpq_archive_path() noexcept {
   auto actual_ptr = reinterpret_cast<MPQArchiveHandle_1_00*>(
       this->Get()
   );

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_const_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_const_wrapper.cc
@@ -73,10 +73,6 @@ UnicodeChar_ConstWrapper& UnicodeChar_ConstWrapper::operator=(
     UnicodeChar_ConstWrapper&& other
 ) noexcept = default;
 
-UnicodeChar_ConstWrapper::operator const UnicodeChar*() const noexcept {
-  return this->Get();
-}
-
 UnicodeChar_ConstWrapper::operator unsigned short() const noexcept {
   return this->GetChar();
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_wrapper.cc
@@ -80,11 +80,7 @@ UnicodeChar_Wrapper& UnicodeChar_Wrapper::operator=(
     UnicodeChar_Wrapper&& other
 ) noexcept = default;
 
-UnicodeChar_Wrapper::operator UnicodeChar*() const noexcept {
-  return this->Get();
-}
-
-UnicodeChar* UnicodeChar_Wrapper::Get() const noexcept {
+UnicodeChar* UnicodeChar_Wrapper::Get() noexcept {
   return this->ptr_;
 }
 


### PR DESCRIPTION
There are new API changes to MPQArchiveHandle and UnicodeChar to make their function names more consistent with other classes, as well as address issues with getters. In addition, several C interface function export issues have been addressed. The MPQArchiveHandle API class is now capable of constructing and deconstructing safely.

The following game functions have been added:
- [D2Lang Unicode tolower](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/11)
- [D2Lang Unicode toupper](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/12)
- [D2Lang GetStringByIndex](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/13), resolves #2 
- [D2Win LoadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/16), resolves #213 
- [D2Win UnloadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/17)
- [Fog AllocClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/18)
- [Fog FreeClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/19)
- [Storm SFileCloseArchive](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/20)
- [Storm SFileOpenArchive](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/21)

The following game data have been added:
- [D2DDraw DisplayWidth and DisplayHeight](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/14)
- [D2Direct3D DisplayWidth and DisplayHeight](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/15)
- [D2GDI BitBlockWidth and BitBlockHeight](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/22)
- [D2GDI CelDisplayLeft and CelDisplayRight](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/23)
