### PR TITLE
Add TextColor

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_constant.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_constant.h
@@ -47,6 +47,7 @@
 #define SGD2MAPI_C_GAME_CONSTANT_H_
 
 #include "game_constant/d2_difficulty_level.h"
+#include "game_constant/d2_text_color.h"
 #include "game_constant/d2_video_mode.h"
 
 #endif // SGD2MAPI_C_GAME_CONSTANT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_constant/d2_text_color.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_constant/d2_text_color.h
@@ -43,12 +43,48 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_CONSTANT_HPP_
-#define SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+#ifndef SGD2MAPI_C_GAME_CONSTANT_D2_TEXT_COLOR_H_
+#define SGD2MAPI_C_GAME_CONSTANT_D2_TEXT_COLOR_H_
 
-#include "game_constant/d2_constant.hpp"
-#include "game_constant/d2_difficulty_level.hpp"
-#include "game_constant/d2_text_color.hpp"
-#include "game_constant/d2_video_mode.hpp"
+#include "../../dllexport_define.inc"
 
-#endif // SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+enum D2_TextColor {
+  TEXT_COLOR_WHITE,
+  TEXT_COLOR_RED,
+  TEXT_COLOR_GREEN,
+  TEXT_COLOR_BLUE,
+  TEXT_COLOR_GOLD,
+  TEXT_COLOR_DARK_GREY,
+  TEXT_COLOR_BLACK,
+  TEXT_COLOR_TAN,
+  TEXT_COLOR_ORANGE,
+  TEXT_COLOR_YELLOW,
+  TEXT_COLOR_DARKER_GREEN,
+  TEXT_COLOR_PURPLE,
+  TEXT_COLOR_DARK_GREEN,
+
+  // TEXT_COLOR_WHITE (same as 1) = 13,
+  // TEXT_COLOR_BLACK (same as 6),
+
+  TEXT_COLOR_METALLIC = 15,
+  TEXT_COLOR_LIGHT_GREY,
+  TEXT_COLOR_CORRUPT,
+  TEXT_COLOR_BRIGHT_WHITE,
+  TEXT_COLOR_DARK_RED,
+  TEXT_COLOR_BROWN
+};
+
+DLLEXPORT int D2_TextColor_ToGameValue(int id);
+
+DLLEXPORT int D2_TextColor_ToAPIValue(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_CONSTANT_D2_TEXT_COLOR_H_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_text_color.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_constant/d2_text_color.hpp
@@ -43,12 +43,54 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_CONSTANT_HPP_
-#define SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+#ifndef SGD2MAPI_CXX_GAME_CONSTANT_D2_TEXT_COLOR_HPP_
+#define SGD2MAPI_CXX_GAME_CONSTANT_D2_TEXT_COLOR_HPP_
 
-#include "game_constant/d2_constant.hpp"
-#include "game_constant/d2_difficulty_level.hpp"
-#include "game_constant/d2_text_color.hpp"
-#include "game_constant/d2_video_mode.hpp"
+#include <cstddef>
 
-#endif // SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+#include "d2_constant.hpp"
+
+#include "../../dllexport_define.inc"
+
+namespace d2 {
+
+enum class TextColor {
+  kWhite,
+  kRed,
+  kGreen,
+  kBlue,
+  kGold,
+  kDarkGrey,
+  kBlack,
+  kTan,
+  kOrange,
+  kYellow,
+  kDarkerGreen,
+  kPurple,
+  kDarkGreen,
+
+  // kWhite (same as 1) = 13,
+  // kBlack (same as 6),
+
+  kMetallic = 15,
+  kLightGrey,
+  kCorrupt,
+  kBrightWhite,
+  kDarkRed,
+  kBrown
+};
+
+extern template DLLEXPORT
+int ToGameValue(
+    TextColor id
+);
+
+extern template DLLEXPORT
+TextColor ToAPIValue(
+    int value
+);
+
+} // namespace d2
+
+#include "../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_CONSTANT_D2_TEXT_COLOR_HPP_

--- a/SlashGaming-Diablo-II-API/src/c/game_constant/c_d2_text_color.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_constant/c_d2_text_color.cc
@@ -43,12 +43,20 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_CONSTANT_HPP_
-#define SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+#include "../../../include/c/game_constant/d2_text_color.h"
 
-#include "game_constant/d2_constant.hpp"
-#include "game_constant/d2_difficulty_level.hpp"
-#include "game_constant/d2_text_color.hpp"
-#include "game_constant/d2_video_mode.hpp"
+#include "../../../include/cxx/game_constant/d2_text_color.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+int D2_TextColor_ToGameValue(int id) {
+  d2::TextColor actual_id =
+      static_cast<d2::TextColor>(id);
+
+  return d2::ToGameValue(actual_id);
+}
+
+int D2_TextColor_ToAPIValue(int value) {
+  d2::TextColor actual_id =
+      d2::ToAPIValue<d2::TextColor>(value);
+
+  return static_cast<int>(actual_id);
+}

--- a/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_text_color.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_text_color.cc
@@ -43,12 +43,27 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_CONSTANT_HPP_
-#define SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "game_constant/d2_constant.hpp"
-#include "game_constant/d2_difficulty_level.hpp"
-#include "game_constant/d2_text_color.hpp"
-#include "game_constant/d2_video_mode.hpp"
+#include "../../../include/cxx/game_constant/d2_text_color.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_CONSTANT_HPP_
+#include <cstddef>
+
+#include "../../../include/cxx/game_constant/d2_constant.hpp"
+#include "d2_constant_impl.hpp"
+
+namespace d2 {
+
+template int
+ToGameValue(
+    TextColor id
+);
+
+template TextColor
+ToAPIValue(
+    int value
+);
+
+} // namespace d2


### PR DESCRIPTION
The constant `TextColor` is used to determine which color to use in text display. The values' relations to the colors can be found by locating the D2Win DrawText function and overriding the `text_color` parameter with any of the other possible values.

## Definition
### All Versions
```
0 = White
1 = Red (Light Red)
2 = Green (Light Green)
3 = Blue
4 = Gold
5 = Dark Grey
6 = Black
7 = Tan
8 = Orange
9 = Yellow
10 = Darker Green
11 = Purple
12 = Dark Green
13 = White (same as 1)
14 = Black (same as 6)
15 = Metallic
16 = Light Grey
17 = Corrupt Colors (Not Pleasing to the eye)
18 = Bright White
19 = Dark Red
20 = Brown
```

## Screenshots
The following 1.00 screenshots depict all of the colors in order. Pay attention to the belt.
![TextColor_00_(1 00)](https://user-images.githubusercontent.com/26683324/60774339-ddb3e080-a0c7-11e9-8dc4-6429f450935f.jpg)
![TextColor_01_(1 00)](https://user-images.githubusercontent.com/26683324/60774340-ddb3e080-a0c7-11e9-954c-1157709cc525.jpg)
![TextColor_02_(1 00)](https://user-images.githubusercontent.com/26683324/60774341-ddb3e080-a0c7-11e9-99dd-def4fa478687.jpg)
![TextColor_03_(1 00)](https://user-images.githubusercontent.com/26683324/60774342-de4c7700-a0c7-11e9-8fb9-58d1d223e2fd.jpg)
![TextColor_04_(1 00)](https://user-images.githubusercontent.com/26683324/60774343-de4c7700-a0c7-11e9-8fd9-c199b15e58b0.jpg)
![TextColor_05_(1 00)](https://user-images.githubusercontent.com/26683324/60774344-de4c7700-a0c7-11e9-9a17-5fd9c076bcc3.jpg)
![TextColor_06_(1 00)](https://user-images.githubusercontent.com/26683324/60774345-de4c7700-a0c7-11e9-9a94-f2ce2e371c7a.jpg)
![TextColor_07_(1 00)](https://user-images.githubusercontent.com/26683324/60774346-de4c7700-a0c7-11e9-8acf-97405e8a790b.jpg)
![TextColor_08_(1 00)](https://user-images.githubusercontent.com/26683324/60774347-de4c7700-a0c7-11e9-8fe7-eea9bbf96386.jpg)
![TextColor_09_(1 00)](https://user-images.githubusercontent.com/26683324/60774348-de4c7700-a0c7-11e9-86fc-818a63f3665e.jpg)
![TextColor_10_(1 00)](https://user-images.githubusercontent.com/26683324/60774349-de4c7700-a0c7-11e9-96c4-9ad3513265ad.jpg)
![TextColor_11_(1 00)](https://user-images.githubusercontent.com/26683324/60774350-dee50d80-a0c7-11e9-8367-9f50901a5824.jpg)
![TextColor_12_(1 00)](https://user-images.githubusercontent.com/26683324/60774351-dee50d80-a0c7-11e9-82a3-7b90c52b3dfb.jpg)
![TextColor_13_(1 00)](https://user-images.githubusercontent.com/26683324/60774352-dee50d80-a0c7-11e9-93dd-ea859ebdd810.jpg)
![TextColor_14_(1 00)](https://user-images.githubusercontent.com/26683324/60774353-dee50d80-a0c7-11e9-9b59-a01ee4766070.jpg)
![TextColor_15_(1 00)](https://user-images.githubusercontent.com/26683324/60774354-dee50d80-a0c7-11e9-9169-262824293a47.jpg)
![TextColor_16_(1 00)](https://user-images.githubusercontent.com/26683324/60774355-dee50d80-a0c7-11e9-88a8-8947add51f1c.jpg)
![TextColor_17_(1 00)](https://user-images.githubusercontent.com/26683324/60774356-dee50d80-a0c7-11e9-9db9-a3f058fa9618.jpg)
![TextColor_18_(1 00)](https://user-images.githubusercontent.com/26683324/60774357-df7da400-a0c7-11e9-86da-29aee66bb5a6.jpg)
![TextColor_19_(1 00)](https://user-images.githubusercontent.com/26683324/60774358-df7da400-a0c7-11e9-839c-0f6cfe6b9527.jpg)
![TextColor_20_(1 00)](https://user-images.githubusercontent.com/26683324/60774359-df7da400-a0c7-11e9-93f9-b9d637b52f7c.jpg)
