### PR TITLE
Remove u8 prefix from all strings

### DIFF
--- a/SlashGaming-Diablo-II-API/src/c/c_default_game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/c/c_default_game_library.cc
@@ -56,7 +56,7 @@ char* MAPI_GetGameExecutablePath(
     char* dest
 ) {
   std::string game_executable_path_text =
-      mapi::GetGameExecutablePath().u8string();
+      mapi::GetGameExecutablePath().string();
 
   std::copy(
       game_executable_path_text.cbegin(),
@@ -68,7 +68,7 @@ char* MAPI_GetGameExecutablePath(
 }
 
 std::size_t MAPI_GetGameExecutablePathSize() {
-  return mapi::GetGameExecutablePath().u8string().size() + 1;
+  return mapi::GetGameExecutablePath().string().size() + 1;
 }
 
 char* MAPI_GetDefaultLibraryPathWithRedirect(
@@ -82,7 +82,7 @@ char* MAPI_GetDefaultLibraryPathWithRedirect(
       mapi::GetDefaultLibraryPathWithRedirect(actual_default_library);
 
   std::string default_library_path_text =
-      default_library_path.u8string();
+      default_library_path.string();
 
   std::copy(
       default_library_path_text.cbegin(),
@@ -102,5 +102,5 @@ std::size_t MAPI_GetDefaultLibraryPathWithRedirectSize(
   const std::filesystem::path& default_library_path =
       mapi::GetDefaultLibraryPathWithRedirect(actual_default_library);
 
-  return default_library_path.u8string().size() + 1;
+  return default_library_path.string().size() + 1;
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/config.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/config.cc
@@ -59,35 +59,35 @@
 namespace mapi {
 namespace {
 
-constexpr std::string_view kGlobalEntryKey = u8"!!!Globals!!!";
-constexpr std::string_view kConfigTabWidthKey = u8"Config Tab Width";
+constexpr std::string_view kGlobalEntryKey = "!!!Globals!!!";
+constexpr std::string_view kConfigTabWidthKey = "Config Tab Width";
 constexpr int kDefaultConfigTabWidthValue = 4;
 
-constexpr std::string_view kMainEntryKey = u8"SlashGaming Diablo II Modding API";
+constexpr std::string_view kMainEntryKey = "SlashGaming Diablo II Modding API";
 
-constexpr std::string_view kMetaDataKey = u8"!!!Metadata (Do not modify)!!!";
+constexpr std::string_view kMetaDataKey = "!!!Metadata (Do not modify)!!!";
 
 // Note that this signifies the last version where the config formatting and
 // entries were updated. These values do not need to change with respect to API
 // file version!
-constexpr std::string_view kMajorVersionAKey = u8"Major Version A";
+constexpr std::string_view kMajorVersionAKey = "Major Version A";
 constexpr int kMajorVersionAValue = 0;
-constexpr std::string_view kMajorVersionBKey = u8"Major Version B";
+constexpr std::string_view kMajorVersionBKey = "Major Version B";
 constexpr int kMajorVersionBValue = 1;
-constexpr std::string_view kMinorVersionAKey = u8"Minor Version A";
+constexpr std::string_view kMinorVersionAKey = "Minor Version A";
 constexpr int kMinorVersionAValue = 0;
-constexpr std::string_view kMinorVersionBKey = u8"Minor Version B";
+constexpr std::string_view kMinorVersionBKey = "Minor Version B";
 constexpr int kMinorVersionBValue = 0;
 
 constexpr std::string_view kAddressTableDirectoryPathKey =
-    u8"Address Table Directory Path";
+    "Address Table Directory Path";
 const std::filesystem::path kDefaultAddressTableDirectoryPath =
-    u8"Address Table";
+    "Address Table";
 
 std::map<std::string, std::once_flag> once_flags_by_json_keys;
 
 const std::filesystem::path& GetConfigPath() {
-  static std::filesystem::path kConfigPath = u8"SlashGaming-Config.json";
+  static std::filesystem::path kConfigPath = "SlashGaming-Config.json";
   return kConfigPath;
 }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
@@ -71,26 +71,26 @@ const PathsByDefaultLibrariesMap&
 GetPathsByDefaultLibraryMap() {
   static const PathsByDefaultLibrariesMap
   paths_by_default_libraries = {
-      { DefaultLibrary::kBNClient, u8"BNClient.dll" },
-      { DefaultLibrary::kD2Client, u8"D2Client.dll" },
-      { DefaultLibrary::kD2CMP, u8"D2CMP.dll" },
-      { DefaultLibrary::kD2Common, u8"D2Common.dll" },
-      { DefaultLibrary::kD2DDraw, u8"D2DDraw.dll" },
-      { DefaultLibrary::kD2Direct3D, u8"D2Direct3D.dll" },
-      { DefaultLibrary::kD2Game, u8"D2Game.dll" },
-      { DefaultLibrary::kD2GDI, u8"D2GDI.dll" },
-      { DefaultLibrary::kD2GFX, u8"D2GFX.dll" },
-      { DefaultLibrary::kD2Glide, u8"D2Glide.dll" },
-      { DefaultLibrary::kD2Lang, u8"D2Lang.dll" },
-      { DefaultLibrary::kD2Launch, u8"D2Launch.dll" },
-      { DefaultLibrary::kD2MCPClient, u8"D2MCPClient.dll" },
-      { DefaultLibrary::kD2Multi, u8"D2Multi.dll" },
-      { DefaultLibrary::kD2Net, u8"D2Net.dll" },
-      { DefaultLibrary::kD2Server, u8"D2Server.dll" },
-      { DefaultLibrary::kD2Sound, u8"D2Sound.dll" },
-      { DefaultLibrary::kD2Win, u8"D2Win.dll" },
-      { DefaultLibrary::kFog, u8"Fog.dll" },
-      { DefaultLibrary::kStorm, u8"Storm.dll" }
+      { DefaultLibrary::kBNClient, "BNClient.dll" },
+      { DefaultLibrary::kD2Client, "D2Client.dll" },
+      { DefaultLibrary::kD2CMP, "D2CMP.dll" },
+      { DefaultLibrary::kD2Common, "D2Common.dll" },
+      { DefaultLibrary::kD2DDraw, "D2DDraw.dll" },
+      { DefaultLibrary::kD2Direct3D, "D2Direct3D.dll" },
+      { DefaultLibrary::kD2Game, "D2Game.dll" },
+      { DefaultLibrary::kD2GDI, "D2GDI.dll" },
+      { DefaultLibrary::kD2GFX, "D2GFX.dll" },
+      { DefaultLibrary::kD2Glide, "D2Glide.dll" },
+      { DefaultLibrary::kD2Lang, "D2Lang.dll" },
+      { DefaultLibrary::kD2Launch, "D2Launch.dll" },
+      { DefaultLibrary::kD2MCPClient, "D2MCPClient.dll" },
+      { DefaultLibrary::kD2Multi, "D2Multi.dll" },
+      { DefaultLibrary::kD2Net, "D2Net.dll" },
+      { DefaultLibrary::kD2Server, "D2Server.dll" },
+      { DefaultLibrary::kD2Sound, "D2Sound.dll" },
+      { DefaultLibrary::kD2Win, "D2Win.dll" },
+      { DefaultLibrary::kFog, "Fog.dll" },
+      { DefaultLibrary::kStorm, "Storm.dll" }
   };
 
   return paths_by_default_libraries;
@@ -100,7 +100,7 @@ GetPathsByDefaultLibraryMap() {
 
 const std::filesystem::path&
 GetGameExecutablePath() {
-  static std::filesystem::path kGameExecutable = u8"Game.exe";
+  static std::filesystem::path kGameExecutable = "Game.exe";
 
   return kGameExecutable;
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address_table.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address_table.cc
@@ -76,7 +76,7 @@ GetTableFilePath() {
 
   std::filesystem::path table_file_path(address_table_directory);
   table_file_path /= running_game_version_name;
-  table_file_path += u8".txt";
+  table_file_path += ".txt";
 
   return table_file_path;
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address_table_reader.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address_table_reader.cc
@@ -66,13 +66,13 @@
 namespace mapi {
 namespace {
 
-constexpr std::string_view kLocatorTypeKey = u8"Locator Type";
-constexpr std::string_view kLocatorValueKey = u8"Locator Value";
+constexpr std::string_view kLocatorTypeKey = "Locator Type";
+constexpr std::string_view kLocatorValueKey = "Locator Value";
 
-constexpr std::string_view kLocatorTypeOffset = u8"Offset";
-constexpr std::string_view kLocatorTypeOrdinal = u8"Ordinal";
-constexpr std::string_view kLocatorTypeDecoratedName = u8"Decorated Name";
-constexpr std::string_view kLocatorTypeNA = u8"N/A";
+constexpr std::string_view kLocatorTypeOffset = "Offset";
+constexpr std::string_view kLocatorTypeOrdinal = "Ordinal";
+constexpr std::string_view kLocatorTypeDecoratedName = "Decorated Name";
+constexpr std::string_view kLocatorTypeNA = "N/A";
 
 GameAddress
 ResolveAddress(
@@ -134,7 +134,7 @@ ReadTsvTableFile(
     const std::filesystem::path& table_file_path
 ) {
   static const std::regex kLineRegex(
-      u8"(.*?)\t(.*?)\t(.*?)\t([^\t]*)(.*)",
+      "(.*?)\t(.*?)\t(.*?)\t([^\t]*)(.*)",
       std::regex_constants::ECMAScript | std::regex::icase
   );
 
@@ -195,7 +195,7 @@ ReadTsvTableFile(
     const std::string& locator_type = matches[3];
     const std::string& locator_value = matches[4];
 
-    std::filesystem::path library_path = std::filesystem::u8path(
+    std::filesystem::path library_path = std::filesystem::path(
         library_path_text
     );
 
@@ -208,8 +208,8 @@ ReadTsvTableFile(
 
     library_path.replace_extension();
 
-    std::string full_address_name = library_path.filename().u8string()
-        + u8"_"
+    std::string full_address_name = library_path.filename().string()
+        + "_"
         + address_name;
 
     address_table.insert_or_assign(

--- a/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_constant_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_constant/d2_constant_impl.hpp
@@ -54,7 +54,7 @@ template <typename ConstantType>
 int ToGameValue(ConstantType id) {
   static_assert(
       std::is_enum<ConstantType>::value,
-      u8"The specified type is not a constant."
+      "The specified type is not a constant."
   );
 
   return static_cast<int>(id);
@@ -64,7 +64,7 @@ template <typename ConstantType>
 ConstantType ToAPIValue(int value) {
   static_assert(
       std::is_enum<ConstantType>::value,
-      u8"The specified type is not a constant."
+      "The specified type is not a constant."
   );
 
   return static_cast<ConstantType>(value);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_file/d2_cel_file_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_file/d2_cel_file_wrapper.cc
@@ -289,7 +289,7 @@ bool CelFile_Wrapper::DrawVerticalThenHorizontal(
         all_frames_options.vertical_direction
     );
 
-    final_result = final_result && current_frame;
+    final_result = final_result && current_result;
 
     Cel_ConstWrapper current_cel(
         this->GetCel(all_frames_options.cel_file_direction, current_frame)
@@ -328,7 +328,7 @@ bool CelFile_Wrapper::DrawRowOfFrames(
   for (int i = 0; i < columns; i += 1) {
     unsigned int current_frame = i + first_frame;
 
-    bool current_frame = this->DrawFrame(
+    bool current_result = this->DrawFrame(
         frame_position_x,
         position_y,
         direction,
@@ -336,7 +336,7 @@ bool CelFile_Wrapper::DrawRowOfFrames(
         frame_options
     );
 
-    final_result = final_result && current_frame;
+    final_result = final_result && current_result;
 
     Cel_ConstWrapper current_cel(this->GetCel(direction, current_frame));
     frame_position_x += (current_cel.GetWidth() * direction_factor);
@@ -381,7 +381,7 @@ bool CelFile_Wrapper::DrawColumnOfFrames(
         frame_options
     );
 
-    final_result = final_result && current_frame;
+    final_result = final_result && current_result;
 
     Cel_ConstWrapper current_cel(this->GetCel(direction, current_frame));
     frame_position_y += (current_cel.GetHeight() * direction_factor);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
@@ -70,7 +70,7 @@ MPQArchiveHandle_API::MPQArchiveHandle_API(
     int priority
 ) : MPQArchiveHandle_Wrapper(
         d2win::LoadMPQ(
-            mpq_file_path.u8string().data(),
+            mpq_file_path.string().data(),
             is_set_error_on_drive_query_fail,
             on_fail_callback,
             priority

--- a/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
@@ -80,37 +80,37 @@ GetGameVersionsByFileVersions() {
   > game_versions_by_file_versions = {
         // 1.00 & 1.01 have the same version #, but use completely different
         // DLLs.
-        { u8"1.0.0.1", GameVersion::k1_01 },
-        { u8"1.0.2.0", GameVersion::k1_02 },
-        { u8"1.0.3.0", GameVersion::k1_03 },
+        { "1.0.0.1", GameVersion::k1_01 },
+        { "1.0.2.0", GameVersion::k1_02 },
+        { "1.0.3.0", GameVersion::k1_03 },
         // 1.04B and 1.04C use the same DLLs.
-        { u8"1.0.4.1", GameVersion::k1_04B_C },
-        { u8"1.0.4.2", GameVersion::k1_04B_C },
-        { u8"1.0.5.0", GameVersion::k1_05 },
-        { u8"1.0.5.1", GameVersion::k1_05B },
+        { "1.0.4.1", GameVersion::k1_04B_C },
+        { "1.0.4.2", GameVersion::k1_04B_C },
+        { "1.0.5.0", GameVersion::k1_05 },
+        { "1.0.5.1", GameVersion::k1_05B },
         // 1.06 & 1.06B have the same version #, but use completely different
         // DLLs.
-        { u8"1.0.6.0", GameVersion::k1_06 },
+        { "1.0.6.0", GameVersion::k1_06 },
         // 1.07 Beta & 1.07 have the same version #, but use completely
         // different DLLs.
-        { u8"1.0.7.0", GameVersion::k1_07 },
-        { u8"1.0.8.28", GameVersion::k1_08 },
-        { u8"1.0.9.19", GameVersion::k1_09 },
-        { u8"1.0.9.20", GameVersion::k1_09B },
-        { u8"1.0.9.22", GameVersion::k1_09D },
-        { u8"1.0.10.9", GameVersion::k1_10Beta },
-        { u8"1.0.10.10", GameVersion::k1_10SBeta },
-        { u8"1.0.10.39", GameVersion::k1_10 },
-        { u8"1.0.11.45", GameVersion::k1_11 },
-        { u8"1.0.11.46", GameVersion::k1_11B },
-        { u8"1.0.12.49", GameVersion::k1_12A },
-        { u8"1.0.13.55", GameVersion::k1_13ABeta },
-        { u8"1.0.13.60", GameVersion::k1_13C },
-        { u8"1.0.13.64", GameVersion::k1_13D },
-        { u8"1.14.0.64", GameVersion::kLod1_14A },
-        { u8"1.14.1.68", GameVersion::kLod1_14B },
-        { u8"1.14.2.70", GameVersion::kLod1_14C },
-        { u8"1.14.3.71", GameVersion::kLod1_14D }
+        { "1.0.7.0", GameVersion::k1_07 },
+        { "1.0.8.28", GameVersion::k1_08 },
+        { "1.0.9.19", GameVersion::k1_09 },
+        { "1.0.9.20", GameVersion::k1_09B },
+        { "1.0.9.22", GameVersion::k1_09D },
+        { "1.0.10.9", GameVersion::k1_10Beta },
+        { "1.0.10.10", GameVersion::k1_10SBeta },
+        { "1.0.10.39", GameVersion::k1_10 },
+        { "1.0.11.45", GameVersion::k1_11 },
+        { "1.0.11.46", GameVersion::k1_11B },
+        { "1.0.12.49", GameVersion::k1_12A },
+        { "1.0.13.55", GameVersion::k1_13ABeta },
+        { "1.0.13.60", GameVersion::k1_13C },
+        { "1.0.13.64", GameVersion::k1_13D },
+        { "1.14.0.64", GameVersion::kLod1_14A },
+        { "1.14.1.68", GameVersion::kLod1_14B },
+        { "1.14.2.70", GameVersion::kLod1_14C },
+        { "1.14.3.71", GameVersion::kLod1_14D }
   };
 
   return game_versions_by_file_versions;
@@ -125,39 +125,39 @@ GetGameVersionNamesByGameVersionIds() {
       GameVersion,
       std::string_view
   > game_version_names_by_game_version_ids = {
-        { GameVersion::k1_00, u8"1.00" },
-        { GameVersion::k1_01, u8"1.01" },
-        { GameVersion::k1_02, u8"1.02" },
-        { GameVersion::k1_03, u8"1.03" },
+        { GameVersion::k1_00, "1.00" },
+        { GameVersion::k1_01, "1.01" },
+        { GameVersion::k1_02, "1.02" },
+        { GameVersion::k1_03, "1.03" },
         // 1.04B and 1.04C use the same DLLs.
-        { GameVersion::k1_04B_C, u8"1.04B/C" },
-        { GameVersion::k1_05, u8"1.05" },
-        { GameVersion::k1_05B, u8"1.05B" },
-        { GameVersion::k1_06, u8"1.06" },
-        { GameVersion::k1_06B, u8"1.06B" },
-        { GameVersion::k1_07Beta, u8"1.07 Beta" },
-        { GameVersion::k1_07, u8"1.07" },
-        { GameVersion::k1_08, u8"1.08" },
-        { GameVersion::k1_09, u8"1.09" },
-        { GameVersion::k1_09B, u8"1.09B" },
-        { GameVersion::k1_09D, u8"1.09D" },
-        { GameVersion::k1_10Beta, u8"1.10 Beta" },
-        { GameVersion::k1_10SBeta, u8"1.10S Beta" },
-        { GameVersion::k1_10, u8"1.10" },
-        { GameVersion::k1_11, u8"1.11" },
-        { GameVersion::k1_11B, u8"1.11B" },
-        { GameVersion::k1_12A, u8"1.12A" },
-        { GameVersion::k1_13ABeta, u8"1.13A Beta" },
-        { GameVersion::k1_13C, u8"1.13C" },
-        { GameVersion::k1_13D, u8"1.13D" },
-        { GameVersion::kClassic1_14A, u8"Classic 1.14A" },
-        { GameVersion::kLod1_14A, u8"LoD 1.14A" },
-        { GameVersion::kClassic1_14B, u8"Classic 1.14B" },
-        { GameVersion::kLod1_14B, u8"LoD 1.14B" },
-        { GameVersion::kClassic1_14C, u8"Classic 1.14C" },
-        { GameVersion::kLod1_14C, u8"LoD 1.14C" },
-        { GameVersion::kClassic1_14D, u8"Classic 1.14D" },
-        { GameVersion::kLod1_14D, u8"LoD 1.14D" }
+        { GameVersion::k1_04B_C, "1.04B/C" },
+        { GameVersion::k1_05, "1.05" },
+        { GameVersion::k1_05B, "1.05B" },
+        { GameVersion::k1_06, "1.06" },
+        { GameVersion::k1_06B, "1.06B" },
+        { GameVersion::k1_07Beta, "1.07 Beta" },
+        { GameVersion::k1_07, "1.07" },
+        { GameVersion::k1_08, "1.08" },
+        { GameVersion::k1_09, "1.09" },
+        { GameVersion::k1_09B, "1.09B" },
+        { GameVersion::k1_09D, "1.09D" },
+        { GameVersion::k1_10Beta, "1.10 Beta" },
+        { GameVersion::k1_10SBeta, "1.10S Beta" },
+        { GameVersion::k1_10, "1.10" },
+        { GameVersion::k1_11, "1.11" },
+        { GameVersion::k1_11B, "1.11B" },
+        { GameVersion::k1_12A, "1.12A" },
+        { GameVersion::k1_13ABeta, "1.13A Beta" },
+        { GameVersion::k1_13C, "1.13C" },
+        { GameVersion::k1_13D, "1.13D" },
+        { GameVersion::kClassic1_14A, "Classic 1.14A" },
+        { GameVersion::kLod1_14A, "LoD 1.14A" },
+        { GameVersion::kClassic1_14B, "Classic 1.14B" },
+        { GameVersion::kLod1_14B, "LoD 1.14B" },
+        { GameVersion::kClassic1_14C, "Classic 1.14C" },
+        { GameVersion::kLod1_14C, "LoD 1.14C" },
+        { GameVersion::kClassic1_14D, "Classic 1.14D" },
+        { GameVersion::kLod1_14D, "LoD 1.14D" }
   };
 
   return game_version_names_by_game_version_ids;
@@ -260,7 +260,7 @@ ExtractFileVersionString(
   // DWORD is always 32 bits, so first two revision numbers
   // come from dwFileVersionMS, last two come from dwFileVersionLS
   return fmt::format(
-      u8"{}.{}.{}.{}",
+      "{}.{}.{}.{}",
       (version_info->dwFileVersionMS >> 16) & 0xFFFF,
       (version_info->dwFileVersionMS >> 0) & 0xFFFF,
       (version_info->dwFileVersionLS >> 16) & 0xFFFF,
@@ -324,7 +324,7 @@ GetGameVersionByLibraryData(
           0xF0
       };
 
-      library_path = u8"D2Client.dll";
+      library_path = "D2Client.dll";
       offset_value = 0x3C;
       matching_version = GameVersion::k1_00;
       non_matching_version = GameVersion::k1_01;
@@ -337,7 +337,7 @@ GetGameVersionByLibraryData(
           0x3F
       };
 
-      library_path = u8"D2Client.dll",
+      library_path = "D2Client.dll",
       offset_value = 0xE8;
       matching_version = GameVersion::k1_06;
       non_matching_version = GameVersion::k1_06B;
@@ -350,7 +350,7 @@ GetGameVersionByLibraryData(
           0xF0
       };
 
-      library_path = u8"D2Client.dll";
+      library_path = "D2Client.dll";
       offset_value = 0x3C;
       matching_version = GameVersion::k1_07Beta;
       non_matching_version = GameVersion::k1_07;
@@ -363,7 +363,7 @@ GetGameVersionByLibraryData(
           0x38
       };
 
-      library_path = u8"Game.exe";
+      library_path = "Game.exe";
       offset_value = 0x120;
       matching_version = GameVersion::kClassic1_14A;
       non_matching_version = GameVersion::kLod1_14A;
@@ -376,7 +376,7 @@ GetGameVersionByLibraryData(
           0xAE
       };
 
-      library_path = u8"Game.exe";
+      library_path = "Game.exe";
       offset_value = 0x110;
       matching_version = GameVersion::kClassic1_14B;
       non_matching_version = GameVersion::kLod1_14B;
@@ -389,7 +389,7 @@ GetGameVersionByLibraryData(
           0x52
       };
 
-      library_path = u8"Game.exe";
+      library_path = "Game.exe";
       offset_value = 0x110;
       matching_version = GameVersion::kClassic1_14C;
       non_matching_version = GameVersion::kLod1_14C;
@@ -402,7 +402,7 @@ GetGameVersionByLibraryData(
           0xC4
       };
 
-      library_path = u8"Game.exe";
+      library_path = "Game.exe";
       offset_value = 0x128;
       matching_version = GameVersion::kClassic1_14D;
       non_matching_version = GameVersion::kLod1_14D;


### PR DESCRIPTION
This is temporary until char8_t ports exist for libraries and an
appropriate conversion can be done.