### PR TITLE
Add static assertions to structs

### DIFF
--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel/d2_cel_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel/d2_cel_impl.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2MAPI_CXX_GAME_STRUCT_D2_CEL_D2_CEL_IMPL_HPP_
 #define SGD2MAPI_CXX_GAME_STRUCT_D2_CEL_D2_CEL_IMPL_HPP_
 
+#include <cstddef>
+
 #include "../../../../include/cxx/game_struct/d2_cel.hpp"
 #include "../../../../include/cxx/game_undefined.hpp"
 
@@ -61,6 +63,12 @@ namespace d2 {
   /* 0x0C */ std::int32_t offset_x;
   /* 0x10 */ std::int32_t offset_y;
 };
+
+static_assert(sizeof(Cel_1_00) >= 0x14);
+static_assert(offsetof(Cel_1_00, width) == 0x04);
+static_assert(offsetof(Cel_1_00, height) == 0x08);
+static_assert(offsetof(Cel_1_00, offset_x) == 0x0C);
+static_assert(offsetof(Cel_1_00, offset_y) == 0x10);
 
 #pragma pack(pop)
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_context/d2_cel_context_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_context/d2_cel_context_impl.hpp
@@ -46,8 +46,9 @@
 #ifndef SGD2MAPI_CXX_GAME_STRUCT_D2_CEL_CONTEXT_D2_CEL_CONTEXT_IMPL_HPP_
 #define SGD2MAPI_CXX_GAME_STRUCT_D2_CEL_CONTEXT_D2_CEL_CONTEXT_IMPL_HPP_
 
-#include "../../../../include/cxx/game_struct/d2_cel_context.hpp"
+#include <cstddef>
 
+#include "../../../../include/cxx/game_struct/d2_cel_context.hpp"
 #include "../d2_cel_file/d2_cel_file_impl.hpp"
 #include "../../../../include/cxx/game_undefined.hpp"
 
@@ -56,12 +57,17 @@ namespace d2 {
 #pragma pack(push, 1)
 
 /* sizeof: 0x48 */ struct CelContext_1_00 {
-  /* 0x00 */ mapi::UndefinedByte unknown_0x00;
+  /* 0x00 */ mapi::UndefinedByte unknown_0x00[0x04 - 0x00];
   /* 0x04 */ CelFile_1_00* cel_file;
   /* 0x08 */ std::uint32_t frame;
   /* 0x0C */ std::uint32_t direction;
   /* 0x10 */ mapi::UndefinedByte unknown_0x10[0x48 - 0x10];
 };
+
+static_assert(sizeof(CelContext_1_00) == 0x48);
+static_assert(offsetof(CelContext_1_00, cel_file) == 0x04);
+static_assert(offsetof(CelContext_1_00, frame) == 0x08);
+static_assert(offsetof(CelContext_1_00, direction) == 0x0C);
 
 /* sizeof: 0x48 */ struct CelContext_1_12A {
   /* 0x00 */ mapi::UndefinedByte unknown_0x00[0x38 - 0x00];
@@ -71,6 +77,11 @@ namespace d2 {
   /* 0x44 */ mapi::UndefinedByte unknown_0x44[0x48 - 0x44];
 };
 
+static_assert(sizeof(CelContext_1_12A) == 0x48);
+static_assert(offsetof(CelContext_1_12A, cel_file) == 0x3C);
+static_assert(offsetof(CelContext_1_12A, frame) == 0x40);
+static_assert(offsetof(CelContext_1_12A, direction) == 0x38);
+
 /* sizeof: 0x48 */ struct CelContext_1_13C {
   /* 0x00 */ std::uint32_t frame;
   /* 0x04 */ mapi::UndefinedByte unknown_0x04[0x34 - 0x04];
@@ -79,6 +90,11 @@ namespace d2 {
   /* 0x40 */ std::uint32_t direction;
   /* 0x44 */ mapi::UndefinedByte unknown_0x44[0x48 - 0x44];
 };
+
+static_assert(sizeof(CelContext_1_13C) == 0x48);
+static_assert(offsetof(CelContext_1_13C, cel_file) == 0x34);
+static_assert(offsetof(CelContext_1_13C, frame) == 0x00);
+static_assert(offsetof(CelContext_1_13C, direction) == 0x40);
 
 #pragma pack(pop)
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_file/d2_cel_file_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_file/d2_cel_file_impl.hpp
@@ -53,13 +53,18 @@ namespace d2 {
 
 #pragma pack(push, 1)
 
-/* sizeof: 0x14 + sizeof(cels) */ struct CelFile_1_00 {
+/* sizeof: 0x18 + sizeof(cels) */ struct CelFile_1_00 {
   /* 0x00 */ std::uint32_t version;
   /* 0x04 */ mapi::UndefinedByte unknown_0x04[0x10 - 0x04];
   /* 0x10 */ std::uint32_t num_directions;
   /* 0x14 */ std::uint32_t num_frames;
   /* 0x18 */ mapi::UndefinedByte cels[0]; // This field gives the struct variable length.
 };
+
+static_assert(sizeof(CelFile_1_00) >= 0x18);
+static_assert(offsetof(CelFile_1_00, version) == 0x00);
+static_assert(offsetof(CelFile_1_00, num_directions) == 0x10);
+static_assert(offsetof(CelFile_1_00, num_frames) == 0x14);
 
 #pragma pack(pop)
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_impl.hpp
@@ -46,8 +46,9 @@
 #ifndef SGD2MAPI_CXX_GAME_STRUCT_D2_MPQ_ARCHIVE_HANDLE_D2_MPQ_ARCHIVE_HANDLE_IMPL_HPP_
 #define SGD2MAPI_CXX_GAME_STRUCT_D2_MPQ_ARCHIVE_HANDLE_D2_MPQ_ARCHIVE_HANDLE_IMPL_HPP_
 
-#include "../../../../include/cxx/game_struct/d2_mpq_archive_handle.hpp"
+#include <cstddef>
 
+#include "../../../../include/cxx/game_struct/d2_mpq_archive_handle.hpp"
 #include "../../../../include/cxx/game_struct/d2_mpq_archive.hpp"
 #include "../d2_mpq_archive/d2_mpq_archive_impl.hpp"
 
@@ -59,6 +60,10 @@ namespace d2 {
   /* 0x0 */ MPQArchive_1_00* mpq_archive;
   /* 0x4 */ char mpq_archive_path[/* 0x104 */ 260];
 };
+
+static_assert(sizeof(MPQArchiveHandle_1_00) >= 0x108);
+static_assert(offsetof(MPQArchiveHandle_1_00, mpq_archive) == 0x00);
+static_assert(offsetof(MPQArchiveHandle_1_00, mpq_archive_path) == 0x04);
 
 #pragma pack(pop)
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_unicode_char/d2_unicode_char_impl.hpp
@@ -46,10 +46,10 @@
 #ifndef SGD2MAPI_CXX_GAME_STRUCT_D2_UNICODE_CHAR_D2_UNICODE_CHAR_IMPL_HPP_
 #define SGD2MAPI_CXX_GAME_STRUCT_D2_UNICODE_CHAR_D2_UNICODE_CHAR_IMPL_HPP_
 
-#include "../../../../include/cxx/game_struct/d2_unicode_char.hpp"
-
 #include <cstddef>
 #include <cstdint>
+
+#include "../../../../include/cxx/game_struct/d2_unicode_char.hpp"
 
 namespace d2 {
 
@@ -58,6 +58,9 @@ namespace d2 {
 /* sizeof: 0x2 */ struct UnicodeChar_1_00 {
   /* 0x0 */std::uint16_t ch;
 };
+
+static_assert(sizeof(UnicodeChar_1_00) >= 0x02);
+static_assert(offsetof(UnicodeChar_1_00, ch) == 0x00);
 
 #pragma pack(pop)
 


### PR DESCRIPTION
This ensures that structs match their definitions and will fail the
assertions if they do not. This makes it easier to correctly define
struct members and ensure that the struct size is also correct.

This also resulted in an incorrect definition of CelContext to be fixed.