### PR TITLE
Update Addresses to Current

### DIFF
--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_bit_block_height.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_bit_block_height.h
@@ -43,12 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_HEIGHT_H_
+#define SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_HEIGHT_H_
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2DDraw_GetBitBlockHeight(void);
+DLLEXPORT void D2_D2DDraw_SetBitBlockHeight(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_HEIGHT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_bit_block_width.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_bit_block_width.h
@@ -43,12 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_WIDTH_H_
+#define SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_WIDTH_H_
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2DDraw_GetBitBlockWidth(void);
+DLLEXPORT void D2_D2DDraw_SetBitBlockWidth(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_WIDTH_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_cel_display_left.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_cel_display_left.h
@@ -43,14 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_LEFT_H_
+#define SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_LEFT_H_
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2DDraw_GetCelDisplayLeft(void);
+DLLEXPORT void D2_D2DDraw_SetCelDisplayLeft(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_LEFT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_cel_display_right.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw/d2ddraw_cel_display_right.h
@@ -43,14 +43,21 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_RIGHT_H_
+#define SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_RIGHT_H_
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+DLLEXPORT int D2_D2DDraw_GetCelDisplayRight(void);
+DLLEXPORT void D2_D2DDraw_SetCelDisplayRight(int value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_RIGHT_H_

--- a/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw_data.h
+++ b/SlashGaming-Diablo-II-API/include/c/game_data/d2ddraw_data.h
@@ -48,6 +48,8 @@
 
 #include "d2ddraw/d2ddraw_bit_block_height.h"
 #include "d2ddraw/d2ddraw_bit_block_width.h"
+#include "d2ddraw/d2ddraw_cel_display_left.h"
+#include "d2ddraw/d2ddraw_cel_display_right.h"
 #include "d2ddraw/d2ddraw_display_height.h"
 #include "d2ddraw/d2ddraw_display_width.h"
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_bit_block_height.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_bit_block_height.hpp
@@ -43,12 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_HEIGHT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_HEIGHT_HPP_
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+namespace d2::d2ddraw {
+
+DLLEXPORT int GetBitBlockHeight();
+DLLEXPORT void SetBitBlockHeight(int value);
+
+} // namespace d2::d2ddraw
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_HEIGHT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_bit_block_width.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_bit_block_width.hpp
@@ -43,12 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_WIDTH_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_WIDTH_HPP_
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+namespace d2::d2ddraw {
+
+DLLEXPORT int GetBitBlockWidth();
+DLLEXPORT void SetBitBlockWidth(int value);
+
+} // namespace d2::d2ddraw
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_BIT_BLOCK_WIDTH_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_cel_display_left.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_cel_display_left.hpp
@@ -43,14 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_LEFT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_LEFT_HPP_
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+namespace d2::d2ddraw {
+
+DLLEXPORT int GetCelDisplayLeft();
+DLLEXPORT void SetCelDisplayLeft(int value);
+
+} // namespace d2::d2ddraw
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_LEFT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_cel_display_right.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw/d2ddraw_cel_display_right.hpp
@@ -43,14 +43,17 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_RIGHT_HPP_
+#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_RIGHT_HPP_
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../dllexport_define.inc"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+namespace d2::d2ddraw {
+
+DLLEXPORT int GetCelDisplayRight();
+DLLEXPORT void SetCelDisplayRight(int value);
+
+} // namespace d2::d2ddraw
+
+#include "../../../dllexport_undefine.inc"
+#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_D2DDRAW_CEL_DISPLAY_RIGHT_HPP_

--- a/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_data/d2ddraw_data.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
 #define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
 
+#include "d2ddraw/d2ddraw_bit_block_height.hpp"
+#include "d2ddraw/d2ddraw_bit_block_width.hpp"
 #include "d2ddraw/d2ddraw_display_height.hpp"
 #include "d2ddraw/d2ddraw_display_width.hpp"
 

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_bit_block_height.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_bit_block_height.cc
@@ -43,12 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include "../../../../include/c/game_data/d2ddraw/d2ddraw_bit_block_height.h"
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_bit_block_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+int D2_D2DDraw_GetBitBlockHeight() {
+  return d2::d2ddraw::GetBitBlockHeight();
+}
+
+void D2_D2DDraw_SetBitBlockHeight(int value) {
+  d2::d2ddraw::SetBitBlockHeight(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_bit_block_width.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_bit_block_width.cc
@@ -43,12 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include "../../../../include/c/game_data/d2ddraw/d2ddraw_bit_block_width.h"
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_bit_block_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+int D2_D2DDraw_GetBitBlockWidth() {
+  return d2::d2ddraw::GetBitBlockWidth();
+}
+
+void D2_D2DDraw_SetBitBlockWidth(int value) {
+  d2::d2ddraw::SetBitBlockWidth(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_cel_display_left.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_cel_display_left.cc
@@ -43,14 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#include "../../../../include/c/game_data/d2ddraw/d2ddraw_cel_display_left.h"
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_cel_display_left.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+int D2_D2DDraw_GetCelDisplayLeft() {
+  return d2::d2ddraw::GetCelDisplayLeft();
+}
+
+void D2_D2DDraw_SetCelDisplayLeft(int value) {
+  d2::d2ddraw::SetCelDisplayLeft(value);
+}

--- a/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_cel_display_right.cc
+++ b/SlashGaming-Diablo-II-API/src/c/game_data/d2ddraw/c_d2ddraw_cel_display_right.cc
@@ -43,14 +43,14 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#include "../../../../include/c/game_data/d2ddraw/d2ddraw_cel_display_right.h"
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_cel_display_right.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+int D2_D2DDraw_GetCelDisplayRight() {
+  return d2::d2ddraw::GetCelDisplayRight();
+}
+
+void D2_D2DDraw_SetCelDisplayRight(int value) {
+  d2::d2ddraw::SetCelDisplayRight(value);
+}

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_bit_block_height.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_bit_block_height.cc
@@ -43,12 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_bit_block_height.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2ddraw {
+namespace {
+
+std::intptr_t D2DDraw_BitBlockHeight() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetBitBlockHeight() {
+  std::intptr_t ptr = D2DDraw_BitBlockHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetBitBlockHeight(int value) {
+  std::intptr_t ptr = D2DDraw_BitBlockHeight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2ddraw

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_bit_block_width.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_bit_block_width.cc
@@ -43,12 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
-#define SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2ddraw/d2ddraw_bit_block_height.h"
-#include "d2ddraw/d2ddraw_bit_block_width.h"
-#include "d2ddraw/d2ddraw_display_height.h"
-#include "d2ddraw/d2ddraw_display_width.h"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_bit_block_width.hpp"
 
-#endif // SGD2MAPI_C_GAME_DATA_D2DDRAW_DATA_H_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2ddraw {
+namespace {
+
+std::intptr_t D2DDraw_BitBlockWidth() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetBitBlockWidth() {
+  std::intptr_t ptr = D2DDraw_BitBlockWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetBitBlockWidth(int value) {
+  std::intptr_t ptr = D2DDraw_BitBlockWidth();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2ddraw

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_cel_display_left.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_cel_display_left.cc
@@ -43,14 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_cel_display_left.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2ddraw {
+namespace {
+
+std::intptr_t D2DDraw_CelDisplayLeft() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetCelDisplayLeft() {
+  std::intptr_t ptr = D2DDraw_CelDisplayLeft();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetCelDisplayLeft(int value) {
+  std::intptr_t ptr = D2DDraw_CelDisplayLeft();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2ddraw

--- a/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_cel_display_right.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_data/d2ddraw/d2ddraw_cel_display_right.cc
@@ -43,14 +43,41 @@
  *  work.
  */
 
-#ifndef SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
-#define SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+/**
+ * Latest supported version: 1.14D
+ */
 
-#include "d2ddraw/d2ddraw_bit_block_height.hpp"
-#include "d2ddraw/d2ddraw_bit_block_width.hpp"
-#include "d2ddraw/d2ddraw_cel_display_left.hpp"
-#include "d2ddraw/d2ddraw_cel_display_right.hpp"
-#include "d2ddraw/d2ddraw_display_height.hpp"
-#include "d2ddraw/d2ddraw_display_width.hpp"
+#include "../../../../include/cxx/game_data/d2ddraw/d2ddraw_cel_display_right.hpp"
 
-#endif // SGD2MAPI_CXX_GAME_DATA_D2DDRAW_DATA_HPP_
+#include <cstdint>
+
+#include "../../../cxx/game_address_table.hpp"
+#include "../../../../include/cxx/game_version.hpp"
+
+namespace d2::d2ddraw {
+namespace {
+
+std::intptr_t D2DDraw_CelDisplayRight() {
+  static std::intptr_t ptr = mapi::GetGameAddress(__func__)
+      .raw_address();
+
+  return ptr;
+}
+
+} // namespace
+
+int GetCelDisplayRight() {
+  std::intptr_t ptr = D2DDraw_CelDisplayRight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  return *converted_ptr;
+}
+
+void SetCelDisplayRight(int value) {
+  std::intptr_t ptr = D2DDraw_CelDisplayRight();
+
+  std::int32_t* converted_ptr = reinterpret_cast<std::int32_t*>(ptr);
+  *converted_ptr = value;
+}
+
+} // namespace d2::d2ddraw


### PR DESCRIPTION
The following variables have been added:
- [D2DDraw BitBlockWidth](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/45)
- [D2DDraw BitBlockHeight](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/45)
- [D2Draw CelDisplayLeft](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/46)
- [D2Draw CelDisplayRight](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/46)