### PR TITLE
Add C++98 transitional functions

### DIFF
--- a/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
@@ -62,6 +62,10 @@ namespace mapi {
  */
 class DLLEXPORT GameAddress {
  public:
+  constexpr GameAddress() noexcept
+      : GameAddress(0) {
+  }
+
   constexpr std::intptr_t raw_address() const noexcept {
     return this->raw_address_;
   }

--- a/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
@@ -124,6 +124,10 @@ class DLLEXPORT GameAddress {
       std::int16_t ordinal
   );
 
+  constexpr void Swap(GameAddress& game_address) noexcept {
+    ::std::swap(this->raw_address_, game_address.raw_address_);
+  }
+
  private:
   constexpr explicit GameAddress(std::intptr_t raw_address) noexcept
       : raw_address_(raw_address) {

--- a/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
@@ -217,6 +217,8 @@ class DLLEXPORT GamePatch {
       std::size_t patch_size
   );
 
+  void Swap(GamePatch& game_patch) noexcept;
+
  private:
   GamePatch(
       const GameAddress& game_address,

--- a/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
@@ -66,6 +66,8 @@ class DLLEXPORT GamePatch {
   static constexpr const std::size_t kBranchPatchMinSize =
       sizeof(void(*)()) + sizeof(std::uint8_t);
 
+  GamePatch();
+
   GamePatch(const GamePatch& game_patch) = delete;
 
   GamePatch(GamePatch&& game_patch) noexcept;

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
@@ -187,6 +187,13 @@ void GamePatch::Remove() {
   this->is_patch_applied_ = false;
 }
 
+void GamePatch::Swap(GamePatch& game_patch) noexcept {
+  this->game_address_.Swap(game_patch.game_address_);
+  ::std::swap(this->is_patch_applied_, game_patch.is_patch_applied_);
+  this->patch_buffer_.swap(game_patch.patch_buffer_);
+  this->unpatched_buffer_.swap(game_patch.unpatched_buffer_);
+}
+
 const GameAddress& GamePatch::game_address() const noexcept {
   return this->game_address_;
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
@@ -58,6 +58,13 @@
 
 namespace mapi {
 
+GamePatch::GamePatch()
+    : game_address_(),
+      is_patch_applied_(false),
+      patch_buffer_(),
+      unpatched_buffer_() {
+}
+
 GamePatch::GamePatch(
     const GameAddress& game_address,
     const std::vector<std::uint8_t>& patch_buffer


### PR DESCRIPTION
These functions are intended to help ease into SGD2MAPI98, if the programmer chooses to use it. This is done by adding default constructors and swap functions for game patch and game address.