### PR TITLE
Add lower-case swap functions to patch and address

### DIFF
--- a/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
@@ -124,6 +124,10 @@ class DLLEXPORT GameAddress {
       std::int16_t ordinal
   );
 
+  constexpr void swap(GameAddress& game_address) noexcept {
+    ::std::swap(this->raw_address_, game_address.raw_address_);
+  }
+
   constexpr void Swap(GameAddress& game_address) noexcept {
     ::std::swap(this->raw_address_, game_address.raw_address_);
   }

--- a/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_patch.hpp
@@ -217,6 +217,8 @@ class DLLEXPORT GamePatch {
       std::size_t patch_size
   );
 
+  void swap(GamePatch& game_patch) noexcept;
+
   void Swap(GamePatch& game_patch) noexcept;
 
  private:

--- a/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_patch.cc
@@ -187,6 +187,10 @@ void GamePatch::Remove() {
   this->is_patch_applied_ = false;
 }
 
+void GamePatch::swap(GamePatch& game_patch) noexcept {
+  this->Swap(game_patch);
+}
+
 void GamePatch::Swap(GamePatch& game_patch) noexcept {
   this->game_address_.Swap(game_patch.game_address_);
   ::std::swap(this->is_patch_applied_, game_patch.is_patch_applied_);


### PR DESCRIPTION
These lower-case variants allow the types to fulfill the requirements of Swappable.