### PR TITLE
Rename CelContext struct data members

### DIFF
--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_api.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_api.hpp
@@ -161,28 +161,28 @@ class DLLEXPORT CelContext_Api {
     wrapper.SetCelFile(cel_file);
   }
 
-  constexpr unsigned int GetDirection() const noexcept {
+  constexpr unsigned int GetDirectionIndex() const noexcept {
     CelContext_View view(*this);
 
-    return view.GetDirection();
+    return view.GetDirectionIndex();
   }
 
-  constexpr void SetDirection(unsigned int direction) noexcept {
+  constexpr void SetDirectionIndex(unsigned int direction_index) noexcept {
     CelContext_Wrapper wrapper(*this);
 
-    wrapper.SetDirection(direction);
+    wrapper.SetDirectionIndex(direction_index);
   }
 
-  constexpr unsigned int GetFrame() const noexcept {
+  constexpr unsigned int GetFrameIndex() const noexcept {
     CelContext_View view(*this);
 
-    return view.GetFrame();
+    return view.GetFrameIndex();
   }
 
-  constexpr void SetFrame(unsigned int frame) noexcept {
+  constexpr void SetFrameIndex(unsigned int frame_index) noexcept {
     CelContext_Wrapper wrapper(*this);
 
-    wrapper.SetFrame(frame);
+    wrapper.SetFrameIndex(frame_index);
   }
 
  private:
@@ -190,8 +190,8 @@ class DLLEXPORT CelContext_Api {
 
   static ApiVariant CreateVariant(
       CelFile* cel_file,
-      unsigned int direction,
-      unsigned int frame
+      unsigned int direction_index,
+      unsigned int frame_index
   );
 };
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_struct.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_struct.hpp
@@ -65,8 +65,8 @@ struct CelContext;
 /* sizeof: 0x48 */ struct CelContext_1_00 {
   /* 0x00 */ mapi::UndefinedByte unknown_0x00[0x04 - 0x00];
   /* 0x04 */ CelFile_1_00* cel_file;
-  /* 0x08 */ std::uint32_t frame;
-  /* 0x0C */ std::uint32_t direction;
+  /* 0x08 */ std::uint32_t frame_index;
+  /* 0x0C */ std::uint32_t direction_index;
   /* 0x10 */ mapi::UndefinedByte unknown_0x10[0x48 - 0x10];
 };
 
@@ -74,14 +74,14 @@ static_assert(std::is_standard_layout_v<CelContext_1_00>);
 static_assert(std::is_trivial_v<CelContext_1_00>);
 static_assert(sizeof(CelContext_1_00) == 0x48);
 static_assert(offsetof(CelContext_1_00, cel_file) == 0x04);
-static_assert(offsetof(CelContext_1_00, frame) == 0x08);
-static_assert(offsetof(CelContext_1_00, direction) == 0x0C);
+static_assert(offsetof(CelContext_1_00, frame_index) == 0x08);
+static_assert(offsetof(CelContext_1_00, direction_index) == 0x0C);
 
 /* sizeof: 0x48 */ struct CelContext_1_12A {
   /* 0x00 */ mapi::UndefinedByte unknown_0x00[0x38 - 0x00];
-  /* 0x38 */ std::uint32_t direction;
+  /* 0x38 */ std::uint32_t direction_index;
   /* 0x3C */ CelFile_1_00* cel_file;
-  /* 0x40 */ std::uint32_t frame;
+  /* 0x40 */ std::uint32_t frame_index;
   /* 0x44 */ mapi::UndefinedByte unknown_0x44[0x48 - 0x44];
 };
 
@@ -89,15 +89,15 @@ static_assert(std::is_standard_layout_v<CelContext_1_12A>);
 static_assert(std::is_trivial_v<CelContext_1_12A>);
 static_assert(sizeof(CelContext_1_12A) == 0x48);
 static_assert(offsetof(CelContext_1_12A, cel_file) == 0x3C);
-static_assert(offsetof(CelContext_1_12A, frame) == 0x40);
-static_assert(offsetof(CelContext_1_12A, direction) == 0x38);
+static_assert(offsetof(CelContext_1_12A, frame_index) == 0x40);
+static_assert(offsetof(CelContext_1_12A, direction_index) == 0x38);
 
 /* sizeof: 0x48 */ struct CelContext_1_13C {
-  /* 0x00 */ std::uint32_t frame;
+  /* 0x00 */ std::uint32_t frame_index;
   /* 0x04 */ mapi::UndefinedByte unknown_0x04[0x34 - 0x04];
   /* 0x34 */ CelFile_1_00* cel_file;
   /* 0x38 */ mapi::UndefinedByte unknown_0x38[0x40 - 0x38];
-  /* 0x40 */ std::uint32_t direction;
+  /* 0x40 */ std::uint32_t direction_index;
   /* 0x44 */ mapi::UndefinedByte unknown_0x44[0x48 - 0x44];
 };
 
@@ -105,8 +105,8 @@ static_assert(std::is_standard_layout_v<CelContext_1_13C>);
 static_assert(std::is_trivial_v<CelContext_1_13C>);
 static_assert(sizeof(CelContext_1_13C) == 0x48);
 static_assert(offsetof(CelContext_1_13C, cel_file) == 0x34);
-static_assert(offsetof(CelContext_1_13C, frame) == 0x00);
-static_assert(offsetof(CelContext_1_13C, direction) == 0x40);
+static_assert(offsetof(CelContext_1_13C, frame_index) == 0x00);
+static_assert(offsetof(CelContext_1_13C, direction_index) == 0x40);
 
 #pragma pack(pop)
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_view.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_view.hpp
@@ -123,19 +123,19 @@ class DLLEXPORT CelContext_View {
     );
   }
 
-  constexpr unsigned int GetDirection() const noexcept {
+  constexpr unsigned int GetDirectionIndex() const noexcept {
     return std::visit(
         [](const auto& actual_cel_context) {
-          return actual_cel_context->direction;
+          return actual_cel_context->direction_index;
         },
         this->cel_context_
     );
   }
 
-  constexpr unsigned int GetFrame() const noexcept {
+  constexpr unsigned int GetFrameIndex() const noexcept {
     return std::visit(
         [](const auto& actual_cel_context) {
-          return actual_cel_context->frame;
+          return actual_cel_context->frame_index;
         },
         this->cel_context_
     );

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_wrapper.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_wrapper.hpp
@@ -201,31 +201,31 @@ class DLLEXPORT CelContext_Wrapper {
     );
   }
 
-  constexpr unsigned int GetDirection() const noexcept {
+  constexpr unsigned int GetDirectionIndex() const noexcept {
     CelContext_View view(*this);
 
-    return view.GetDirection();
+    return view.GetDirectionIndex();
   }
 
-  constexpr void SetDirection(unsigned int direction) noexcept {
+  constexpr void SetDirectionIndex(unsigned int direction_index) noexcept {
     std::visit(
-        [direction](auto& actual_cel_context) {
-          actual_cel_context->direction = direction;
+        [direction_index](auto& actual_cel_context) {
+          actual_cel_context->direction_index = direction_index;
         },
         this->cel_context_
     );
   }
 
-  constexpr unsigned int GetFrame() const noexcept {
+  constexpr unsigned int GetFrameIndex() const noexcept {
     CelContext_View view(*this);
 
-    return view.GetFrame();
+    return view.GetFrameIndex();
   }
 
-  constexpr void SetFrame(unsigned int frame) noexcept {
+  constexpr void SetFrameIndex(unsigned int frame_index) noexcept {
     std::visit(
-        [frame](auto& actual_cel_context) {
-          actual_cel_context->direction = frame;
+        [frame_index](auto& actual_cel_context) {
+          actual_cel_context->direction_index = frame_index;
         },
         this->cel_context_
     );

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_context/d2_cel_context_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_context/d2_cel_context_api.cc
@@ -80,8 +80,8 @@ Cel* CelContext_Api::GetCel() {
 
 CelContext_Api::ApiVariant CelContext_Api::CreateVariant(
     CelFile* cel_file,
-    unsigned int direction,
-    unsigned int frame
+    unsigned int direction_index,
+    unsigned int frame_index
 ) {
   ApiVariant cel_context;
 
@@ -96,7 +96,7 @@ CelContext_Api::ApiVariant CelContext_Api::CreateVariant(
   }
 
   std::visit(
-      [cel_file, direction, frame](auto& actual_cel_context) {
+      [cel_file, direction_index, frame_index](auto& actual_cel_context) {
         using CelContext_T = std::remove_reference_t<
             decltype(actual_cel_context)
         >;
@@ -107,8 +107,8 @@ CelContext_Api::ApiVariant CelContext_Api::CreateVariant(
         actual_cel_context = {};
         actual_cel_context.cel_file =
             reinterpret_cast<CelFile_T*>(cel_file);
-        actual_cel_context.direction = direction;
-        actual_cel_context.frame = frame;
+        actual_cel_context.direction_index = direction_index;
+        actual_cel_context.frame_index = frame_index;
       },
       cel_context
   );


### PR DESCRIPTION
This improves the documentation of the data members and also makes the names more consistent with those in SGD2MAPI98.