### PR TITLE
Remove std::filesystem

### DIFF
--- a/SlashGaming-Diablo-II-API/include/cxx/default_game_library.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/default_game_library.hpp
@@ -46,8 +46,6 @@
 #ifndef SGD2MAPI_CXX_DEFAULT_GAME_LIBRARY_HPP_
 #define SGD2MAPI_CXX_DEFAULT_GAME_LIBRARY_HPP_
 
-#include <filesystem>
-
 #include "../dllexport_define.inc"
 
 namespace d2 {
@@ -66,17 +64,13 @@ namespace default_library {
 /**
  * Returns the path of the specified default library.
  */
-DLLEXPORT const std::filesystem::path& GetPathWithoutRedirect(
-    DefaultLibrary library
-);
+DLLEXPORT const wchar_t* GetPathWithoutRedirect(DefaultLibrary library);
 
 /**
- * Returns the path of the specified default library or an alternative path if
- * an implementation-defined condition is satisfied.
+ * Returns the path of the specified default library or an alternative
+ * path if an implementation-defined condition is satisfied.
  */
-DLLEXPORT const std::filesystem::path& GetPathWithRedirect(
-    DefaultLibrary library
-);
+DLLEXPORT const wchar_t* GetPathWithRedirect(DefaultLibrary library);
 
 } // namespace default_library
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
@@ -48,7 +48,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <filesystem>
 #include <string_view>
 
 #include "default_game_library.hpp"
@@ -76,7 +75,7 @@ class DLLEXPORT GameAddress {
    */
   static GameAddress FromExportedName(
       ::d2::DefaultLibrary library,
-      ::std::string_view exported_name
+      const char* exported_name
   );
 
   /**
@@ -84,7 +83,7 @@ class DLLEXPORT GameAddress {
    * specify a location in game memory.
    */
   static GameAddress FromExportedName(
-      const ::std::filesystem::path& library_path,
+      const wchar_t* path,
       ::std::string_view exported_name
   );
 
@@ -102,7 +101,7 @@ class DLLEXPORT GameAddress {
    * game memory.
    */
   static GameAddress FromOffset(
-      const std::filesystem::path& library_path,
+      const wchar_t* path,
       std::ptrdiff_t offset
   );
 
@@ -120,7 +119,7 @@ class DLLEXPORT GameAddress {
    * in game memory.
    */
   static GameAddress FromOrdinal(
-      const std::filesystem::path& library_path,
+      const wchar_t* path,
       std::int16_t ordinal
   );
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_executable.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_executable.hpp
@@ -46,8 +46,6 @@
 #ifndef SGD2MAPI_CXX_GAME_EXECUTABLE_HPP_
 #define SGD2MAPI_CXX_GAME_EXECUTABLE_HPP_
 
-#include <filesystem>
-
 #include "../dllexport_define.inc"
 
 namespace mapi::game_executable {
@@ -55,7 +53,7 @@ namespace mapi::game_executable {
 /**
  * Returns the executable used to run the game.
  */
-DLLEXPORT const std::filesystem::path& GetPath();
+DLLEXPORT const wchar_t* GetPath();
 
 /**
  * Returns whether the currently running executable is D2SE.

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_file_signature.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_file_signature.cc
@@ -45,6 +45,7 @@
 
 #include "d2se_file_signature.hpp"
 
+#include <algorithm>
 #include <array>
 
 #include "../game_file/file_signature.hpp"
@@ -83,9 +84,9 @@ static_assert(
 
 } // namespace
 
-bool IsFileD2seExecutable(const ::std::filesystem::path& path) {
+bool IsFileD2seExecutable(const wchar_t* path) {
   FileSignature game_executable_file_signature = FileSignature::ReadFile(
-      path.c_str()
+      path
   );
 
   return ::std::binary_search(

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_file_signature.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_file_signature.cc
@@ -85,7 +85,7 @@ static_assert(
 
 bool IsFileD2seExecutable(const ::std::filesystem::path& path) {
   FileSignature game_executable_file_signature = FileSignature::ReadFile(
-      path
+      path.c_str()
   );
 
   return ::std::binary_search(

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_file_signature.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_file_signature.hpp
@@ -46,11 +46,9 @@
 #ifndef SGMAPI_CXX_BACKEND_D2SE_D2SE_FILE_SIGNATURE_HPP_
 #define SGMAPI_CXX_BACKEND_D2SE_D2SE_FILE_SIGNATURE_HPP_
 
-#include <filesystem>
-
 namespace mapi::d2se::file_signature {
 
-bool IsFileD2seExecutable(const ::std::filesystem::path& path);
+bool IsFileD2seExecutable(const wchar_t* path);
 
 } // namespace mapi::d2se::file_signature
 

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_ini.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_ini.hpp
@@ -47,7 +47,6 @@
 #define SGD2MAPI_CXX_BACKEND_D2SE_D2SE_INI_HPP_
 
 #include <cstddef>
-#include <filesystem>
 #include <string_view>
 
 #include "../../../../include/cxx/game_constant/d2_video_mode.hpp"

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table.hpp
@@ -46,7 +46,6 @@
 #ifndef SGD2MAPI_CXX_BACKEND_GAME_ADDRESS_TABLE_HPP_
 #define SGD2MAPI_CXX_BACKEND_GAME_ADDRESS_TABLE_HPP_
 
-#include <filesystem>
 #include <string_view>
 
 #include "../../../include/cxx/default_game_library.hpp"

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_locator/game_exported_name_locator.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_locator/game_exported_name_locator.cc
@@ -50,7 +50,7 @@ namespace mapi {
 GameAddress GameExportedNameLocator::LocateGameAddress() const noexcept {
   return GameAddress::FromExportedName(
       this->library(),
-      this->exported_name()
+      this->exported_name().data()
   );
 }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_file/file_signature.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_file/file_signature.cc
@@ -50,7 +50,7 @@
 namespace mapi {
 
 FileSignature FileSignature::ReadFile(
-    const ::std::filesystem::path& path
+    const wchar_t* path
 ) {
   std::basic_ifstream<SignatureType::value_type> file_stream(
       path,

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_file/file_signature.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_file/file_signature.hpp
@@ -50,7 +50,6 @@
 #include <cstdint>
 #include <array>
 #include <compare>
-#include <filesystem>
 #include <utility>
 
 namespace mapi {
@@ -96,7 +95,7 @@ class FileSignature {
   ) noexcept = default;
 
   static FileSignature ReadFile(
-      const ::std::filesystem::path& path
+      const wchar_t* path
   );
 
   constexpr const SignatureType& signature() const noexcept {

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_library.cc
@@ -54,14 +54,14 @@
 namespace mapi {
 
 GameLibrary::GameLibrary(
-  std::filesystem::path file_path
+    ::std::wstring path
 )
-    : file_path_(std::move(file_path)),
-      base_address_(this->LoadGameLibraryBaseAddress(this->file_path())) {
+    : path_(std::move(path)),
+      base_address_(this->LoadGameLibraryBaseAddress(this->path().c_str())) {
 }
 
 GameLibrary::GameLibrary(GameLibrary&& rhs) noexcept
-    : file_path_(std::move(rhs.file_path_)),
+    : path_(std::move(rhs.path_)),
       base_address_(std::move(rhs.base_address_)) {
   rhs.base_address_ = reinterpret_cast<std::intptr_t>(nullptr);
 };
@@ -90,7 +90,7 @@ GameLibrary& GameLibrary::operator=(GameLibrary&& rhs) noexcept {
     return *this;
   }
 
-  this->file_path_ = std::move(rhs.file_path_);
+  this->path_ = std::move(rhs.path_);
   this->base_address_ = std::move(rhs.base_address_);
 
   rhs.base_address_ = reinterpret_cast<std::intptr_t>(nullptr);
@@ -98,31 +98,26 @@ GameLibrary& GameLibrary::operator=(GameLibrary&& rhs) noexcept {
   return *this;
 }
 
-const GameLibrary& GameLibrary::GetGameLibrary(
-    const std::filesystem::path& file_path
-) {
-  if (!GetLibrariesByPaths().contains(file_path)) {
+const GameLibrary& GameLibrary::GetGameLibrary(const ::std::wstring& path) {
+  if (!GetLibrariesByPaths().contains(path)) {
     GetLibrariesByPaths().insert(
-        std::pair(file_path, GameLibrary(file_path))
+        std::pair(path, GameLibrary(path))
     );
   }
 
-  assert(GetLibrariesByPaths().contains(file_path));
+  assert(GetLibrariesByPaths().contains(path));
 
-  return GetLibrariesByPaths().at(file_path);
+  return GetLibrariesByPaths().at(path);
 }
 
-std::map<std::filesystem::path, GameLibrary>&
-GameLibrary::GetLibrariesByPaths() {
-  static std::map<std::filesystem::path, GameLibrary> libraries_by_paths;
+std::map<::std::wstring, GameLibrary>& GameLibrary::GetLibrariesByPaths() {
+  static std::map<::std::wstring, GameLibrary> libraries_by_paths;
 
   return libraries_by_paths;
 }
 
-std::intptr_t GameLibrary::LoadGameLibraryBaseAddress(
-    const std::filesystem::path& file_path
-) {
-  HMODULE base_address = LoadLibraryW(file_path.c_str());
+std::intptr_t GameLibrary::LoadGameLibraryBaseAddress(const wchar_t* path) {
+  HMODULE base_address = LoadLibraryW(path);
 
   if (base_address == nullptr) {
     ::mdc::error::ExitOnWindowsFunctionError(

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_library.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_library.hpp
@@ -47,8 +47,8 @@
 #define SGD2MAPI_CXX_GAME_LIBRARY_HPP_
 
 #include <cstdint>
-#include <filesystem>
 #include <map>
+#include <string>
 
 namespace mapi {
 
@@ -60,7 +60,7 @@ class GameLibrary {
   /**
    * Creates a new instance of a GameLibrary using the library path.
    */
-  explicit GameLibrary(std::filesystem::path file_path);
+  explicit GameLibrary(::std::wstring path);
 
   GameLibrary(const GameLibrary& rhs) = delete;
 
@@ -72,9 +72,7 @@ class GameLibrary {
 
   GameLibrary& operator=(GameLibrary&& rhs) noexcept;
 
-  static const GameLibrary& GetGameLibrary(
-      const std::filesystem::path& file_path
-  );
+  static const GameLibrary& GetGameLibrary(const ::std::wstring& path);
 
   /**
    * Returns the base address value of this GameLibrary.
@@ -86,19 +84,17 @@ class GameLibrary {
   /**
    * Returns the library path of this GameLibrary.
    */
-  constexpr const std::filesystem::path& file_path() const noexcept {
-    return this->file_path_;
+  constexpr const ::std::wstring& path() const noexcept {
+    return this->path_;
   }
 
  private:
-  std::filesystem::path file_path_;
+  ::std::wstring path_;
   std::intptr_t base_address_;
 
-  static std::map<std::filesystem::path, GameLibrary>& GetLibrariesByPaths();
+  static std::map<::std::wstring, GameLibrary>& GetLibrariesByPaths();
 
-  static std::intptr_t LoadGameLibraryBaseAddress(
-      const std::filesystem::path& library_path
-  );
+  static std::intptr_t LoadGameLibraryBaseAddress(const wchar_t* path);
 };
 
 } // namespace mapi

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.cc
@@ -47,6 +47,7 @@
 
 #include <algorithm>
 #include <array>
+#include <memory>
 #include <utility>
 
 #include <mdc/error/exit_on_error.hpp>

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.hpp
@@ -49,7 +49,6 @@
 #include <windows.h>
 
 #include <compare>
-#include <filesystem>
 
 #include "../../../../include/cxx/game_version.hpp"
 

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/game_version_file_signature.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/game_version_file_signature.cc
@@ -389,7 +389,7 @@ static d2::GameVersion SearchTable(
       ? game_executable::GetPath()
       : L"Storm.dll";
 
-  FileSignature signature = FileSignature::ReadFile(path);
+  FileSignature signature = FileSignature::ReadFile(path.c_str());
 
   return SearchTable(signature);
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/game_version_file_signature.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/game_version_file_signature.cc
@@ -385,11 +385,11 @@ static d2::GameVersion SearchTable(
 ::d2::GameVersion GetGameVersion(
     bool is_game_version_at_least_1_14
 ) {
-  ::std::filesystem::path path = is_game_version_at_least_1_14
+  const wchar_t* path = is_game_version_at_least_1_14
       ? game_executable::GetPath()
       : L"Storm.dll";
 
-  FileSignature signature = FileSignature::ReadFile(path.c_str());
+  FileSignature signature = FileSignature::ReadFile(path);
 
   return SearchTable(signature);
 }

--- a/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
@@ -45,112 +45,120 @@
 
 #include "../../include/cxx/default_game_library.hpp"
 
-#include <algorithm>
-#include <array>
-#include <utility>
-
 #include <mdc/error/exit_on_error.hpp>
 #include <mdc/wchar_t/filew.h>
 #include "../../include/cxx/game_executable.hpp"
 #include "../../include/cxx/game_version.hpp"
 
-namespace d2::default_library {
-namespace {
+namespace d2 {
+namespace default_library {
 
-using DefaultLibraryPathTableEntry = ::std::pair<
-    DefaultLibrary,
-    std::filesystem::path
->;
-
-struct DefaultLibraryPathTableEntryCompareKey {
-  constexpr bool operator()(
-      const DefaultLibraryPathTableEntry& entry1,
-      const DefaultLibraryPathTableEntry& entry2
-  ) const noexcept {
-    return entry1.first < entry2.first;
-  }
-
-  constexpr bool operator()(
-      DefaultLibrary library,
-      const DefaultLibraryPathTableEntry& entry
-  ) const noexcept {
-    return library < entry.first;
-  }
-
-  constexpr bool operator()(
-      const DefaultLibraryPathTableEntry& entry,
-      DefaultLibrary library
-  ) const noexcept {
-    return entry.first < library;
-  }
-};
-
-static const std::filesystem::path&
-SearchDefaultLibraryPath(DefaultLibrary library) {
-  static const std::array<
-      DefaultLibraryPathTableEntry,
-      20
-  > kDefaultLibraryPathTable = {{
-      { DefaultLibrary::kBNClient, L"BNClient.dll" },
-      { DefaultLibrary::kD2CMP, L"D2CMP.dll" },
-      { DefaultLibrary::kD2Client, L"D2Client.dll" },
-      { DefaultLibrary::kD2Common, L"D2Common.dll" },
-      { DefaultLibrary::kD2DDraw, L"D2DDraw.dll" },
-      { DefaultLibrary::kD2Direct3D, L"D2Direct3D.dll" },
-      { DefaultLibrary::kD2Game, L"D2Game.dll" },
-      { DefaultLibrary::kD2GDI, L"D2GDI.dll" },
-      { DefaultLibrary::kD2GFX, L"D2GFX.dll" },
-      { DefaultLibrary::kD2Glide, L"D2Glide.dll" },
-      { DefaultLibrary::kD2Lang, L"D2Lang.dll" },
-      { DefaultLibrary::kD2Launch, L"D2Launch.dll" },
-      { DefaultLibrary::kD2MCPClient, L"D2MCPClient.dll" },
-      { DefaultLibrary::kD2Multi, L"D2Multi.dll" },
-      { DefaultLibrary::kD2Net, L"D2Net.dll" },
-      { DefaultLibrary::kD2Server, L"D2Server.dll" },
-      { DefaultLibrary::kD2Sound, L"D2Sound.dll" },
-      { DefaultLibrary::kD2Win, L"D2Win.dll" },
-      { DefaultLibrary::kFog, L"Fog.dll" },
-      { DefaultLibrary::kStorm, L"Storm.dll" },
-  }};
-
-  ::std::pair search_range = ::std::equal_range(
-      kDefaultLibraryPathTable.cbegin(),
-      kDefaultLibraryPathTable.cend(),
-      library,
-      DefaultLibraryPathTableEntryCompareKey()
-  );
-
-  if (search_range.first == kDefaultLibraryPathTable.cend()
-      || search_range.first == search_range.second) {
-    ::mdc::error::ExitOnConstantMappingError(
-        __FILEW__,
-        __LINE__,
-        static_cast<int>(library)
-    );
-
-    return kDefaultLibraryPathTable.cend()->second;
-  }
-
-  return search_range.first->second;
-}
-
-} // namespace
-
-const std::filesystem::path& GetPathWithoutRedirect(
+const wchar_t* GetPathWithoutRedirect(
     DefaultLibrary library
 ) {
-  return SearchDefaultLibraryPath(library);
+  switch (library) {
+    case DefaultLibrary::kBNClient: {
+      return L"BNClient.dll";
+    }
+
+    case DefaultLibrary::kD2CMP: {
+      return L"D2CMP.dll";
+    }
+
+    case DefaultLibrary::kD2Client: {
+      return L"D2Client.dll";
+    }
+
+    case DefaultLibrary::kD2Common: {
+      return L"D2Common.dll";
+    }
+
+    case DefaultLibrary::kD2DDraw: {
+      return L"D2DDraw.dll";
+    }
+
+    case DefaultLibrary::kD2Direct3D: {
+      return L"D2Direct3D.dll";
+    }
+
+    case DefaultLibrary::kD2Game: {
+      return L"D2Game.dll";
+    }
+
+    case DefaultLibrary::kD2GDI: {
+      return L"D2GDI.dll";
+    }
+
+    case DefaultLibrary::kD2GFX: {
+      return L"D2GFX.dll";
+    }
+
+    case DefaultLibrary::kD2Glide: {
+      return L"D2Glide.dll";
+    }
+
+    case DefaultLibrary::kD2Lang: {
+      return L"D2Lang.dll";
+    }
+
+    case DefaultLibrary::kD2Launch: {
+      return L"D2Launch.dll";
+    }
+
+    case DefaultLibrary::kD2MCPClient: {
+      return L"D2MCPClient.dll";
+    }
+
+    case DefaultLibrary::kD2Multi: {
+      return L"D2Multi.dll";
+    }
+
+    case DefaultLibrary::kD2Net: {
+      return L"D2Net.dll";
+    }
+
+    case DefaultLibrary::kD2Server: {
+      return L"D2Server.dll";
+    }
+
+    case DefaultLibrary::kD2Sound: {
+      return L"D2Sound.dll";
+    }
+
+    case DefaultLibrary::kD2Win: {
+      return L"D2Win.dll";
+    }
+
+    case DefaultLibrary::kFog: {
+      return L"Fog.dll";
+    }
+
+    case DefaultLibrary::kStorm: {
+      return L"Storm.dll";
+    }
+
+    default: {
+      ::mdc::error::ExitOnConstantMappingError(
+          __FILEW__,
+          __LINE__,
+          static_cast<int>(library)
+      );
+
+      return L"";
+    }
+  }
 }
 
-const std::filesystem::path& GetPathWithRedirect(
+const wchar_t* GetPathWithRedirect(
     DefaultLibrary library
 ) {
   // Redirect if the game version is 1.14 or higher.
   if (::d2::game_version::IsRunningAtLeast1_14()) {
-    return ::mapi::game_executable::GetPath();
+    return ::mapi::game_executable::GetPath().c_str();
   }
 
   return GetPathWithoutRedirect(library);
 }
 
-} // namespace d2::default_library
+} // namespace default_library
+} // namespace d2

--- a/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/default_game_library.cc
@@ -154,7 +154,7 @@ const wchar_t* GetPathWithRedirect(
 ) {
   // Redirect if the game version is 1.14 or higher.
   if (::d2::game_version::IsRunningAtLeast1_14()) {
-    return ::mapi::game_executable::GetPath().c_str();
+    return ::mapi::game_executable::GetPath();
   }
 
   return GetPathWithoutRedirect(library);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
@@ -58,23 +58,22 @@ namespace mapi {
 
 GameAddress GameAddress::FromExportedName(
     ::d2::DefaultLibrary library,
-    ::std::string_view exported_name
+    const char* exported_name
 ) {
-  const ::std::filesystem::path& default_library_path =
-      ::d2::default_library::GetPathWithRedirect(library);
+  const wchar_t* path = ::d2::default_library::GetPathWithRedirect(library);
 
-  return FromExportedName(default_library_path, exported_name);
+  return FromExportedName(path, exported_name);
 }
 
 GameAddress GameAddress::FromExportedName(
-    const ::std::filesystem::path& library_path,
+    const wchar_t* path,
     ::std::string_view exported_name
 ) {
   static constexpr std::size_t kExportedNameWideCapacity = 1024;
 
   static std::array<wchar_t, kExportedNameWideCapacity> exported_name_wide;
 
-  const GameLibrary& game_library = GameLibrary::GetGameLibrary(library_path);
+  const GameLibrary& game_library = GameLibrary::GetGameLibrary(path);
 
   FARPROC raw_address = GetProcAddress(
       reinterpret_cast<HMODULE>(game_library.base_address()),
@@ -100,12 +99,13 @@ GameAddress GameAddress::FromExportedName(
     ::mdc::error::ExitOnGeneralError(
         L"Error",
         L"%ls failed with error code 0x%X. Could not locate exported "
-            L"name %ls.",
+            L"name %ls from the path %ls.",
         __FILEW__,
         __LINE__,
         L"GetProcAddress",
         GetLastError(),
-        exported_name_wide_ptr
+        exported_name_wide_ptr,
+        path
     );
 
     return GameAddress(0);
@@ -118,17 +118,16 @@ GameAddress GameAddress::FromOffset(
     d2::DefaultLibrary library,
     std::ptrdiff_t offset
 ) {
-  const std::filesystem::path& game_library_path =
-      ::d2::default_library::GetPathWithRedirect(library);
+  const wchar_t* path = ::d2::default_library::GetPathWithRedirect(library);
 
-  return FromOffset(game_library_path, offset);
+  return FromOffset(path, offset);
 }
 
 GameAddress GameAddress::FromOffset(
-    const std::filesystem::path& library_path,
+    const wchar_t* path,
     std::ptrdiff_t offset
 ) {
-  const GameLibrary& game_library = GameLibrary::GetGameLibrary(library_path);
+  const GameLibrary& game_library = GameLibrary::GetGameLibrary(path);
 
   return GameAddress(game_library.base_address() + offset);
 }
@@ -137,17 +136,16 @@ GameAddress GameAddress::FromOrdinal(
     d2::DefaultLibrary library,
     std::int16_t ordinal
 ) {
-  const std::filesystem::path& game_library_path =
-      ::d2::default_library::GetPathWithRedirect(library);
+  const wchar_t* path = ::d2::default_library::GetPathWithRedirect(library);
 
-  return FromOrdinal(game_library_path, ordinal);
+  return FromOrdinal(path, ordinal);
 }
 
 GameAddress GameAddress::FromOrdinal(
-    const std::filesystem::path& library_path,
+    const wchar_t* path,
     std::int16_t ordinal
 ) {
-  const GameLibrary& game_library = GameLibrary::GetGameLibrary(library_path);
+  const GameLibrary& game_library = GameLibrary::GetGameLibrary(path);
 
   FARPROC func_address = GetProcAddress(
       reinterpret_cast<HMODULE>(game_library.base_address()),
@@ -164,7 +162,7 @@ GameAddress GameAddress::FromOrdinal(
         L"GetProcAddress",
         GetLastError(),
         ordinal,
-        library_path.c_str()
+        path
     );
 
     return GameAddress(0);

--- a/SlashGaming-Diablo-II-API/src/cxx/game_executable.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_executable.cc
@@ -48,13 +48,14 @@
 #include <windows.h>
 
 #include <memory>
+#include <string>
 
 #include "backend/d2se/d2se_file_signature.hpp"
 
 namespace mapi::game_executable {
 namespace {
 
-static std::filesystem::path InitGameExecutablePath() {
+static ::std::wstring InitGameExecutablePath() {
   DWORD path_len;
   size_t capacity;
   size_t new_capacity = MAX_PATH;
@@ -73,15 +74,15 @@ static std::filesystem::path InitGameExecutablePath() {
 
 } // namespace
 
-const std::filesystem::path& GetPath() {
-  static std::filesystem::path kGameExecutablePath = InitGameExecutablePath();
+const wchar_t* GetPath() {
+  static ::std::wstring kGameExecutablePath = InitGameExecutablePath();
 
-  return kGameExecutablePath;
+  return kGameExecutablePath.c_str();
 }
 
 bool IsD2se() {
   static bool is_d2se = d2se::file_signature::IsFileD2seExecutable(
-      GetPath().c_str()
+      GetPath()
   );
 
   return is_d2se;

--- a/SlashGaming-Diablo-II-API/src/cxx/game_executable.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_executable.cc
@@ -81,7 +81,7 @@ const std::filesystem::path& GetPath() {
 
 bool IsD2se() {
   static bool is_d2se = d2se::file_signature::IsFileD2seExecutable(
-      GetPath()
+      GetPath().c_str()
   );
 
   return is_d2se;

--- a/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
@@ -47,7 +47,6 @@
 
 #include <windows.h>
 #include <cstdint>
-#include <filesystem>
 #include <string>
 #include <string_view>
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
@@ -63,7 +63,7 @@ namespace {
 
 static GameVersion DetermineRunningGameVersion() {
   ::std::wstring_view executable_raw_path =
-      mapi::game_executable::GetPath().c_str();
+      mapi::game_executable::GetPath();
 
   // Check if running on D2SE. If so, use D2SE_SETUP.ini entries.
   if (mapi::game_executable::IsD2se()) {

--- a/SlashGaming-Diablo-II-API/src/cxx/helper/d2_determine_video_mode.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/helper/d2_determine_video_mode.cc
@@ -144,7 +144,7 @@ static VideoMode_1_00 GetRegistryVideoMode() {
 
 VideoMode DetermineVideoMode() {
   ::std::wstring_view executable_raw_path =
-      ::mapi::game_executable::GetPath().c_str();
+      ::mapi::game_executable::GetPath();
 
   if (::mapi::game_executable::IsD2se()) {
     static VideoMode d2se_video_mode = ::mapi::d2se_ini::GetVideoMode();


### PR DESCRIPTION
The filesystem header introduced in C++17 causes a massive bloat in file size and compile time in MSVC. These changes remove all usages of the filesystem header and replaces `std::filesystem::path` with `const wchar_t*` or `std::wstring`.

For comparison, debug single-thread compile time would take around 202 seconds to compile before these changes, and now takes around 70 seconds to compile after these changes. Parallel compile time goes from around 27 seconds to around 10 seconds. Release LIB file size drops from around 440 MB to around 70 MB.