### PR TITLE
Fix string_view abuse

### DIFF
--- a/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_address.hpp
@@ -48,7 +48,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string_view>
+#include <utility>
 
 #include "default_game_library.hpp"
 
@@ -84,7 +84,7 @@ class DLLEXPORT GameAddress {
    */
   static GameAddress FromExportedName(
       const wchar_t* path,
-      ::std::string_view exported_name
+      const char* exported_name
   );
 
   /**

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_file/d2_cel_file_api.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_file/d2_cel_file_api.hpp
@@ -46,7 +46,6 @@
 #ifndef SGD2MAPI_CXX_GAME_STRUCT_D2_CEL_FILE_D2_CEL_FILE_API_HPP_
 #define SGD2MAPI_CXX_GAME_STRUCT_D2_CEL_FILE_D2_CEL_FILE_API_HPP_
 
-#include <string_view>
 #include <variant>
 
 #include "../../helper/d2_draw_options.hpp"
@@ -66,7 +65,7 @@ class DLLEXPORT CelFile_Api {
   CelFile_Api();
 
   CelFile_Api(
-      ::std::string_view cel_file_path,
+      const char* cel_file_path,
       bool is_dcc_else_dc6
   );
 
@@ -119,7 +118,7 @@ class DLLEXPORT CelFile_Api {
   bool IsOpen() const;
 
   void Open(
-    std::string_view cel_file_path,
+    const char* cel_file_path,
     bool is_dcc_else_dc6
   );
 
@@ -146,7 +145,7 @@ class DLLEXPORT CelFile_Api {
   bool is_open_;
 
   static ApiVariant CreateVariant(
-      std::string_view cel_file_path,
+      const char* cel_file_path,
       bool is_dcc_else_dc6
   );
 

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.hpp
@@ -46,7 +46,6 @@
 #ifndef SGD2MAPI_CXX_GAME_STRUCT_D2_MPQ_ARCHIVE_HANDLE_D2_MPQ_ARCHIVE_HANDLE_API_HPP_
 #define SGD2MAPI_CXX_GAME_STRUCT_D2_MPQ_ARCHIVE_HANDLE_D2_MPQ_ARCHIVE_HANDLE_API_HPP_
 
-#include <string_view>
 #include <variant>
 
 #include "d2_mpq_archive_handle_struct.hpp"
@@ -61,13 +60,13 @@ class DLLEXPORT MpqArchiveHandle_Api {
   MpqArchiveHandle_Api();
 
   MpqArchiveHandle_Api(
-      std::string_view mpq_archive_path,
+      const char* mpq_archive_path,
       bool is_set_error_on_drive_query_fail,
       int priority
   );
 
   MpqArchiveHandle_Api(
-      std::string_view mpq_archive_path,
+      const char* mpq_archive_path,
       bool is_set_error_on_drive_query_fail,
       void* (*on_fail_callback)(),
       int priority
@@ -108,12 +107,12 @@ class DLLEXPORT MpqArchiveHandle_Api {
   bool IsOpen() const;
 
   void Open(
-      std::string_view mpq_archive_path,
+      const char* mpq_archive_path,
       bool is_set_error_on_drive_query_fail,
       int priority
   );
   void Open(
-      std::string_view mpq_archive_path,
+      const char* mpq_archive_path,
       bool is_set_error_on_drive_query_fail,
       void* (*on_fail_callback)(),
       int priority
@@ -139,7 +138,7 @@ class DLLEXPORT MpqArchiveHandle_Api {
   bool is_open_;
 
   static ApiVariant CreateVariant(
-      std::string_view mpq_archive_path,
+      const char* mpq_archive_path,
       bool is_set_error_on_drive_query_fail,
       void* (*on_fail_callback)(),
       int priority

--- a/SlashGaming-Diablo-II-API/include/cxx/game_version.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_version.hpp
@@ -46,8 +46,6 @@
 #ifndef SGD2MAPI_CXX_GAME_VERSION_HPP_
 #define SGD2MAPI_CXX_GAME_VERSION_HPP_
 
-#include <string_view>
-
 #include "../dllexport_define.inc"
 
 namespace d2 {
@@ -69,10 +67,16 @@ enum class GameVersion {
 namespace game_version {
 
 /**
- * Returns a view to the UTF-8 encoded string associated with the specified
- * game version.
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the specified game version.
  */
-DLLEXPORT std::u8string_view GetName(GameVersion game_version);
+DLLEXPORT const char* GetName(GameVersion game_version);
+
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the specified game version.
+ */
+DLLEXPORT const char8_t* GetNameUtf8(GameVersion game_version);
 
 /**
  * Returns the identifier of the running game version.
@@ -80,10 +84,16 @@ DLLEXPORT std::u8string_view GetName(GameVersion game_version);
 DLLEXPORT GameVersion GetRunning();
 
 /**
- * Returns a view to the UTF-8 encoded string associated with the running game
- * version.
+ * Returns the UTF-8 encoded null-terminated string associated with the
+ * running game version.
  */
-DLLEXPORT std::u8string_view GetRunningName();
+DLLEXPORT const char* GetRunningName();
+
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with the
+ * running game version.
+ */
+DLLEXPORT const char8_t* GetRunningNameUtf8();
 
 /**
  * Returns whether the specified game version is at least 1.14.

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_game_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_game_version.cc
@@ -145,9 +145,10 @@ static ::d2::GameVersion SearchTable(
       || search_range.first == search_range.second) {
     ::mdc::error::ExitOnGeneralError(
         L"Error",
-        L"Unknown D2SE.ini Diablo II version string %s.",
+        L"Unknown D2SE.ini Diablo II version string %.*ls.",
         __FILEW__,
         __LINE__,
+        version_str.length(),
         version_str.data()
     );
 

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_ini.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_ini.cc
@@ -68,7 +68,7 @@ namespace mapi::d2se_ini {
       L"",
       version_c_str.data(),
       kVersionStringCapacity,
-      kFileName.data()
+      kFileName
   );
 
   if (get_private_profile_string_result == kVersionStringCapacity - 1) {
@@ -91,7 +91,7 @@ namespace mapi::d2se_ini {
       L"USERSETTINGS",
       L"Renderer",
       -1,
-      kFileName.data()
+      kFileName
   );
 
   switch (renderer_value) {
@@ -100,7 +100,7 @@ namespace mapi::d2se_ini {
           L"USERSETTINGS",
           L"WindowMode",
           -1,
-          kFileName.data()
+          kFileName
       );
 
       return (window_mode_value == 1)

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_ini.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/d2se/d2se_ini.hpp
@@ -46,15 +46,12 @@
 #ifndef SGD2MAPI_CXX_BACKEND_D2SE_D2SE_INI_HPP_
 #define SGD2MAPI_CXX_BACKEND_D2SE_D2SE_INI_HPP_
 
-#include <cstddef>
-#include <string_view>
-
 #include "../../../../include/cxx/game_constant/d2_video_mode.hpp"
 #include "../../../../include/cxx/game_version.hpp"
 
 namespace mapi::d2se_ini {
 
-constexpr ::std::wstring_view kFileName = L"./D2SE_SETUP.ini";
+constexpr const wchar_t* kFileName = L"./D2SE_SETUP.ini";
 
 ::d2::GameVersion GetGameVersion();
 

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table.hpp
@@ -46,8 +46,6 @@
 #ifndef SGD2MAPI_CXX_BACKEND_GAME_ADDRESS_TABLE_HPP_
 #define SGD2MAPI_CXX_BACKEND_GAME_ADDRESS_TABLE_HPP_
 
-#include <string_view>
-
 #include "../../../include/cxx/default_game_library.hpp"
 #include "../../../include/cxx/game_address.hpp"
 
@@ -55,7 +53,7 @@ namespace mapi {
 
 GameAddress LoadGameAddress(
     ::d2::DefaultLibrary library,
-    std::string_view address_name
+    const char* address_name
 );
 
 } // namespace mapi

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_locator/game_exported_name_locator.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_locator/game_exported_name_locator.cc
@@ -50,7 +50,7 @@ namespace mapi {
 GameAddress GameExportedNameLocator::LocateGameAddress() const noexcept {
   return GameAddress::FromExportedName(
       this->library(),
-      this->exported_name().data()
+      this->exported_name()
   );
 }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_locator/game_exported_name_locator.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_locator/game_exported_name_locator.hpp
@@ -46,8 +46,6 @@
 #ifndef SGMAPI_CXX_BACKEND_GAME_ADDRESS_TABLE_GAME_ADDRESS_LOCATOR_GAME_EXPORTED_NAME_LOCATOR_HPP_
 #define SGMAPI_CXX_BACKEND_GAME_ADDRESS_TABLE_GAME_ADDRESS_LOCATOR_GAME_EXPORTED_NAME_LOCATOR_HPP_
 
-#include <string_view>
-
 #include "../../../../../include/cxx/game_address.hpp"
 #include "../../../../../include/cxx/default_game_library.hpp"
 
@@ -59,7 +57,7 @@ class GameExportedNameLocator {
 
   constexpr GameExportedNameLocator(
       ::d2::DefaultLibrary library,
-      ::std::string_view exported_name
+      const char* exported_name
   ) noexcept
       : library_(library),
         exported_name_(exported_name) {
@@ -71,13 +69,13 @@ class GameExportedNameLocator {
     return this->library_;
   }
 
-  constexpr ::std::string_view exported_name() const noexcept {
+  constexpr const char* exported_name() const noexcept {
     return this->exported_name_;
   }
 
  private:
   ::d2::DefaultLibrary library_;
-  ::std::string_view exported_name_;
+  const char* exported_name_;
 };
 
 } // namespace mapi

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_table_impl.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_table_impl.cc
@@ -47,7 +47,6 @@
 
 #include <algorithm>
 #include <array>
-#include <string_view>
 
 #include "../../../../include/cxx/game_version.hpp"
 #include "game_address_locator/game_address_locator.hpp"

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_table_impl.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_address_table/game_address_table_impl.hpp
@@ -47,9 +47,9 @@
 #define SGMAPI_CXX_BACKEND_GAME_ADDRESS_TABLE_GAME_ADDRESS_TABLE_IMPL_HPP_
 
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <variant>
-#include <tuple>
 
 #include "../../../../include/cxx/default_game_library.hpp"
 #include "game_address_locator/game_address_locator.hpp"

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.cc
@@ -133,25 +133,20 @@ static_assert(
 
 } // namespace
 
-d2::GameVersion FileVersion::GuessGameVersion(
-    std::wstring_view raw_path
-) {
-  FileVersion file_version = ReadFileVersion(raw_path);
+d2::GameVersion FileVersion::GuessGameVersion(const wchar_t* path) {
+  FileVersion file_version = ReadFileVersion(path);
 
   return SearchTable(file_version);
 }
 
-FileVersion FileVersion::ReadFileVersion(
-    std::wstring_view raw_path
-) {
+FileVersion FileVersion::ReadFileVersion(const wchar_t* path) {
   // All the code for this function originated from StackOverflow user
   // crashmstr. Some parts were refactored for clarity.
-  const wchar_t* file_path_text_cstr = raw_path.data();
 
   // Check version size.
   DWORD ignored;
   DWORD file_version_info_size = GetFileVersionInfoSizeW(
-      file_path_text_cstr,
+      path,
       &ignored
   );
 
@@ -169,8 +164,8 @@ FileVersion FileVersion::ReadFileVersion(
   // Get the file version info.
   auto file_version_info = std::make_unique<wchar_t[]>(file_version_info_size);
   BOOL is_get_file_version_info_success = GetFileVersionInfoW(
-      file_path_text_cstr,
-      ignored,
+      path,
+      ignored = 0,
       file_version_info_size,
       file_version_info.get()
   );
@@ -220,9 +215,7 @@ FileVersion FileVersion::ReadFileVersion(
   );
 }
 
-d2::GameVersion FileVersion::SearchTable(
-    const FileVersion& file_version
-) {
+d2::GameVersion FileVersion::SearchTable(const FileVersion& file_version) {
   std::pair search_range = std::equal_range(
       kFileVersionSortedTable.cbegin(),
       kFileVersionSortedTable.cend(),

--- a/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.hpp
+++ b/SlashGaming-Diablo-II-API/src/cxx/backend/game_version/file_version.hpp
@@ -49,6 +49,7 @@
 #include <windows.h>
 
 #include <compare>
+#include <tuple>
 
 #include "../../../../include/cxx/game_version.hpp"
 
@@ -112,9 +113,7 @@ class FileVersion {
       const FileVersion& rhs
   ) = default;
 
-  static d2::GameVersion GuessGameVersion(
-      std::wstring_view raw_path
-  );
+  static d2::GameVersion GuessGameVersion(const wchar_t* raw_path);
 
   constexpr const VersionType& version() const noexcept {
     return this->version_;
@@ -123,13 +122,9 @@ class FileVersion {
  private:
   VersionType version_;
 
-  static FileVersion ReadFileVersion(
-      std::wstring_view raw_path
-  );
+  static FileVersion ReadFileVersion(const wchar_t* path);
 
-  static d2::GameVersion SearchTable(
-      const FileVersion& file_version
-  );
+  static d2::GameVersion SearchTable(const FileVersion& file_version);
 };
 
 } // namespace mapi::intern

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
@@ -67,7 +67,7 @@ GameAddress GameAddress::FromExportedName(
 
 GameAddress GameAddress::FromExportedName(
     const wchar_t* path,
-    ::std::string_view exported_name
+    const char* exported_name
 ) {
   static constexpr std::size_t kExportedNameWideCapacity = 1024;
 
@@ -77,12 +77,12 @@ GameAddress GameAddress::FromExportedName(
 
   FARPROC raw_address = GetProcAddress(
       reinterpret_cast<HMODULE>(game_library.base_address()),
-      exported_name.data()
+      exported_name
   );
 
   if (raw_address == nullptr) {
     std::size_t exported_name_wide_length = ::mdc::wide::DecodeAsciiLength(
-        exported_name.data()
+        exported_name
     );
 
     const wchar_t* exported_name_wide_ptr;
@@ -92,7 +92,7 @@ GameAddress GameAddress::FromExportedName(
     } else {
       exported_name_wide_ptr = ::mdc::wide::DecodeAscii(
           exported_name_wide.data(),
-          exported_name.data()
+          exported_name
       );
     }
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_address.cc
@@ -46,6 +46,7 @@
 #include "../../include/cxx/game_address.hpp"
 
 #include <windows.h>
+
 #include <cstdint>
 #include <array>
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_file/d2_cel_file_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_file/d2_cel_file_api.cc
@@ -56,7 +56,7 @@ CelFile_Api::CelFile_Api() :
 }
 
 CelFile_Api::CelFile_Api(
-    std::string_view cel_file_path,
+    const char* cel_file_path,
     bool is_dcc_else_dc6
 ) : cel_file_(nullptr),
     is_open_(false) {
@@ -192,7 +192,7 @@ bool CelFile_Api::IsOpen() const {
 }
 
 void CelFile_Api::Open(
-    std::string_view cel_file_path,
+    const char* cel_file_path,
     bool is_dcc_else_dc6
 ) {
   this->Close();
@@ -206,11 +206,11 @@ void CelFile_Api::Open(
 }
 
 CelFile_Api::ApiVariant CelFile_Api::CreateVariant(
-    std::string_view cel_file_path,
+    const char* cel_file_path,
     bool is_dcc_else_dc6
 ) {
   CelFile* cel_file = d2win::LoadCelFile(
-      cel_file_path.data(),
+      cel_file_path,
       is_dcc_else_dc6
   );
 

--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_mpq_archive_handle/d2_mpq_archive_handle_api.cc
@@ -56,7 +56,7 @@ MpqArchiveHandle_Api::MpqArchiveHandle_Api() :
 }
 
 MpqArchiveHandle_Api::MpqArchiveHandle_Api(
-    std::string_view mpq_archive_path,
+    const char* mpq_archive_path,
     bool is_set_error_on_drive_query_fail,
     int priority
 ) : MpqArchiveHandle_Api(
@@ -68,7 +68,7 @@ MpqArchiveHandle_Api::MpqArchiveHandle_Api(
 }
 
 MpqArchiveHandle_Api::MpqArchiveHandle_Api(
-    std::string_view mpq_archive_path,
+    const char* mpq_archive_path,
     bool is_set_error_on_drive_query_fail,
     void* (*on_fail_callback)(),
     int priority
@@ -128,7 +128,7 @@ bool MpqArchiveHandle_Api::IsOpen() const {
 }
 
 void MpqArchiveHandle_Api::Open(
-    std::string_view mpq_archive_path,
+    const char* mpq_archive_path,
     bool is_set_error_on_drive_query_fail,
     int priority
 ) {
@@ -141,7 +141,7 @@ void MpqArchiveHandle_Api::Open(
 }
 
 void MpqArchiveHandle_Api::Open(
-    std::string_view mpq_archive_path,
+    const char* mpq_archive_path,
     bool is_set_error_on_drive_query_fail,
     void* (*on_fail_callback)(),
     int priority
@@ -159,13 +159,13 @@ void MpqArchiveHandle_Api::Open(
 }
 
 MpqArchiveHandle_Api::ApiVariant MpqArchiveHandle_Api::CreateVariant(
-    std::string_view mpq_archive_path,
+    const char* mpq_archive_path,
     bool is_set_error_on_drive_query_fail,
     void* (*on_fail_callback)(),
     int priority
 ) {
   MpqArchiveHandle* mpq_archive_handle = d2win::LoadMpq(
-      mpq_archive_path.data(),
+      mpq_archive_path,
       is_set_error_on_drive_query_fail,
       on_fail_callback,
       priority

--- a/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_version.cc
@@ -47,8 +47,6 @@
 
 #include <windows.h>
 #include <cstdint>
-#include <string>
-#include <string_view>
 
 #include <mdc/error/exit_on_error.hpp>
 #include <mdc/wchar_t/filew.h>
@@ -61,8 +59,7 @@ namespace d2::game_version {
 namespace {
 
 static GameVersion DetermineRunningGameVersion() {
-  ::std::wstring_view executable_raw_path =
-      mapi::game_executable::GetPath();
+  const wchar_t* game_executable_path = mapi::game_executable::GetPath();
 
   // Check if running on D2SE. If so, use D2SE_SETUP.ini entries.
   if (mapi::game_executable::IsD2se()) {
@@ -72,7 +69,7 @@ static GameVersion DetermineRunningGameVersion() {
   // Guess the game version from the executable's file version.
   GameVersion guess_game_version =
       mapi::intern::FileVersion::GuessGameVersion(
-          executable_raw_path
+          game_executable_path
       );
 
   // Validate the game version guess by checking the bytes of game
@@ -92,7 +89,11 @@ static GameVersion DetermineRunningGameVersion() {
 
 } // namespace
 
-std::u8string_view GetName(GameVersion game_version) {
+const char* GetName(GameVersion game_version) {
+  return reinterpret_cast<const char*>(GetNameUtf8(game_version));
+}
+
+const char8_t* GetNameUtf8(GameVersion game_version) {
   switch (game_version) {
     case GameVersion::k1_00: {
       return u8"1.00";
@@ -241,8 +242,12 @@ GameVersion GetRunning() {
   return running_game_version_id;
 }
 
-std::u8string_view GetRunningName() {
-  static std::u8string_view running_game_version_name = GetName(
+const char* GetRunningName() {
+  return reinterpret_cast<const char*>(GetRunningNameUtf8());
+}
+
+const char8_t* GetRunningNameUtf8() {
+  static const char8_t* running_game_version_name = GetNameUtf8(
       ::d2::game_version::GetRunning()
   );
   return running_game_version_name;


### PR DESCRIPTION
Replaces every occurrence of `std::basic_string_view<T>` where a pointer to a null-terminated character array is intended. There is no guarantee that `std::basic_string_view<T>` is a view to a null-terminated string. One specific example is that a string view could be a substring where its ending position is no where even close to a null-terminating character.

One fix that was considered is to make a copy of the string from the `std::basic_string_view<T>`, but this would be an unnecessary slowdown. The SGD2MAPI98 does not have this particular disadvantage, and the reason is clear.

Since it is reasonable to expect a pointer to a character array to be properly null-terminated, it would be better to just use those instead.