### PR TITLE
Fix CelContext wrapper DrawFrame x-positioning

### DIFF
--- a/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_context/d2_cel_context_wrapper.cc
+++ b/SlashGaming-Diablo-II-API/src/cxx/game_struct/d2_cel_context/d2_cel_context_wrapper.cc
@@ -61,6 +61,7 @@ bool CelContext_Wrapper::DrawFrame(int position_x, int position_y) {
   DrawCelFileFrameOptions frame_options;
   frame_options.color = mapi::Rgba32BitColor();
   frame_options.draw_effect = DrawEffect::kNone;
+  frame_options.position_x_behavior = DrawPositionXBehavior::kLeft;
   frame_options.position_y_behavior = DrawPositionYBehavior::kBottom;
 
   return this->DrawFrame(


### PR DESCRIPTION
The x-position behavior was unset. It is now set to default to "left".