### PR TITLE
Fix cel_context conversions and setters

### DIFF
--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_view.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_view.hpp
@@ -69,7 +69,7 @@ class DLLEXPORT CelContext_View {
   CelContext_View(const CelContext* cel_context) noexcept;
 
   constexpr explicit CelContext_View(ViewVariant cel_context) noexcept
-      : cel_context_(::std::move(cel_context_)) {
+      : cel_context_(::std::move(cel_context)) {
   }
 
   constexpr CelContext_View(

--- a/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_wrapper.hpp
+++ b/SlashGaming-Diablo-II-API/include/cxx/game_struct/d2_cel_context/d2_cel_context_wrapper.hpp
@@ -225,7 +225,7 @@ class DLLEXPORT CelContext_Wrapper {
   constexpr void SetFrameIndex(unsigned int frame_index) noexcept {
     std::visit(
         [frame_index](auto& actual_cel_context) {
-          actual_cel_context->direction_index = frame_index;
+          actual_cel_context->frame_index = frame_index;
         },
         this->cel_context_
     );


### PR DESCRIPTION
Fixes a couple of typos in the `CelContext` types.